### PR TITLE
fix(android-manifest): crash when access ing topmost frame in multi-window mode

### DIFF
--- a/packages/template-blank-ng/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-blank-ng/App_Resources/Android/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
 		<activity
 			android:name="com.tns.NativeScriptActivity"
 			android:label="@string/title_activity_kimera"
-			android:configChanges="keyboardHidden|orientation|screenSize"
+			android:configChanges="keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|locale|uiMode"
 			android:theme="@style/LaunchScreenTheme">
 
 			<meta-data android:name="SET_THEME_ON_LAUNCH" android:resource="@style/AppTheme" />

--- a/packages/template-blank-ts/app/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-blank-ts/app/App_Resources/Android/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
 		<activity
 			android:name="com.tns.NativeScriptActivity"
 			android:label="@string/title_activity_kimera"
-			android:configChanges="keyboardHidden|orientation|screenSize"
+			android:configChanges="keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|locale|uiMode"
 			android:theme="@style/LaunchScreenTheme">
 
 			<meta-data android:name="SET_THEME_ON_LAUNCH" android:resource="@style/AppTheme" />

--- a/packages/template-blank-vue/app/App_Resources/Android/AndroidManifest.xml
+++ b/packages/template-blank-vue/app/App_Resources/Android/AndroidManifest.xml
@@ -28,7 +28,7 @@
 		<activity
 			android:name="com.tns.NativeScriptActivity"
 			android:label="@string/title_activity_kimera"
-			android:configChanges="keyboardHidden|orientation|screenSize"
+			android:configChanges="keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|locale|uiMode"
 			android:theme="@style/LaunchScreenTheme">
 
 			<meta-data android:name="SET_THEME_ON_LAUNCH" android:resource="@style/AppTheme" />

--- a/packages/template-blank/app/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-blank/app/App_Resources/Android/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
 		<activity
 			android:name="com.tns.NativeScriptActivity"
 			android:label="@string/title_activity_kimera"
-			android:configChanges="keyboardHidden|orientation|screenSize"
+			android:configChanges="keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|locale|uiMode"
 			android:theme="@style/LaunchScreenTheme">
 
 			<meta-data android:name="SET_THEME_ON_LAUNCH" android:resource="@style/AppTheme" />

--- a/packages/template-drawer-navigation-ng/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-drawer-navigation-ng/App_Resources/Android/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
 		<activity
 			android:name="com.tns.NativeScriptActivity"
 			android:label="@string/title_activity_kimera"
-			android:configChanges="keyboardHidden|orientation|screenSize"
+			android:configChanges="keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|locale|uiMode"
 			android:theme="@style/LaunchScreenTheme">
 
 			<meta-data android:name="SET_THEME_ON_LAUNCH" android:resource="@style/AppTheme" />

--- a/packages/template-drawer-navigation-ts/app/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-drawer-navigation-ts/app/App_Resources/Android/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
 		<activity
 			android:name="com.tns.NativeScriptActivity"
 			android:label="@string/title_activity_kimera"
-			android:configChanges="keyboardHidden|orientation|screenSize"
+			android:configChanges="keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|locale|uiMode"
 			android:theme="@style/LaunchScreenTheme">
 
 			<meta-data android:name="SET_THEME_ON_LAUNCH" android:resource="@style/AppTheme" />

--- a/packages/template-drawer-navigation/app/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-drawer-navigation/app/App_Resources/Android/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
 		<activity
 			android:name="com.tns.NativeScriptActivity"
 			android:label="@string/title_activity_kimera"
-			android:configChanges="keyboardHidden|orientation|screenSize"
+			android:configChanges="keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|locale|uiMode"
 			android:theme="@style/LaunchScreenTheme">
 
 			<meta-data android:name="SET_THEME_ON_LAUNCH" android:resource="@style/AppTheme" />

--- a/packages/template-health-survey-ng/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-health-survey-ng/App_Resources/Android/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
 		<activity
 			android:name="com.tns.NativeScriptActivity"
 			android:label="@string/title_activity_kimera"
-			android:configChanges="keyboardHidden|orientation|screenSize"
+			android:configChanges="keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|locale|uiMode"
 			android:theme="@style/LaunchScreenTheme">
 
 			<meta-data android:name="SET_THEME_ON_LAUNCH" android:resource="@style/AppTheme" />

--- a/packages/template-hello-world-ng/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-hello-world-ng/App_Resources/Android/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
 		<activity
 			android:name="com.tns.NativeScriptActivity"
 			android:label="@string/title_activity_kimera"
-			android:configChanges="keyboardHidden|orientation|screenSize"
+			android:configChanges="keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|locale|uiMode"
 			android:theme="@style/LaunchScreenTheme">
 
 			<meta-data android:name="SET_THEME_ON_LAUNCH" android:resource="@style/AppTheme" />

--- a/packages/template-hello-world-ts/app/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-hello-world-ts/app/App_Resources/Android/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
 		<activity
 			android:name="com.tns.NativeScriptActivity"
 			android:label="@string/title_activity_kimera"
-			android:configChanges="keyboardHidden|orientation|screenSize"
+			android:configChanges="keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|locale|uiMode"
 			android:theme="@style/LaunchScreenTheme">
 
 			<meta-data android:name="SET_THEME_ON_LAUNCH" android:resource="@style/AppTheme" />

--- a/packages/template-hello-world/app/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-hello-world/app/App_Resources/Android/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
 		<activity
 			android:name="com.tns.NativeScriptActivity"
 			android:label="@string/title_activity_kimera"
-			android:configChanges="keyboardHidden|orientation|screenSize"
+			android:configChanges="keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|locale|uiMode"
 			android:theme="@style/LaunchScreenTheme">
 
 			<meta-data android:name="SET_THEME_ON_LAUNCH" android:resource="@style/AppTheme" />

--- a/packages/template-master-detail-kinvey-ng/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-master-detail-kinvey-ng/App_Resources/Android/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
 		<activity
 			android:name="com.tns.NativeScriptActivity"
 			android:label="@string/title_activity_kimera"
-			android:configChanges="keyboardHidden|orientation|screenSize"
+			android:configChanges="keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|locale|uiMode"
 			android:theme="@style/LaunchScreenTheme">
 
 			<meta-data android:name="SET_THEME_ON_LAUNCH" android:resource="@style/AppTheme" />

--- a/packages/template-master-detail-kinvey-ts/app/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-master-detail-kinvey-ts/app/App_Resources/Android/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
 		<activity
 			android:name="com.tns.NativeScriptActivity"
 			android:label="@string/title_activity_kimera"
-			android:configChanges="keyboardHidden|orientation|screenSize"
+			android:configChanges="keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|locale|uiMode"
 			android:theme="@style/LaunchScreenTheme">
 
 			<meta-data android:name="SET_THEME_ON_LAUNCH" android:resource="@style/AppTheme" />

--- a/packages/template-master-detail-kinvey/app/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-master-detail-kinvey/app/App_Resources/Android/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
 		<activity
 			android:name="com.tns.NativeScriptActivity"
 			android:label="@string/title_activity_kimera"
-			android:configChanges="keyboardHidden|orientation|screenSize"
+			android:configChanges="keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|locale|uiMode"
 			android:theme="@style/LaunchScreenTheme">
 
 			<meta-data android:name="SET_THEME_ON_LAUNCH" android:resource="@style/AppTheme" />

--- a/packages/template-master-detail-ng/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-master-detail-ng/App_Resources/Android/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
 		<activity
 			android:name="com.tns.NativeScriptActivity"
 			android:label="@string/title_activity_kimera"
-			android:configChanges="keyboardHidden|orientation|screenSize"
+			android:configChanges="keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|locale|uiMode"
 			android:theme="@style/LaunchScreenTheme">
 
 			<meta-data android:name="SET_THEME_ON_LAUNCH" android:resource="@style/AppTheme" />

--- a/packages/template-master-detail-ts/app/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-master-detail-ts/app/App_Resources/Android/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
 		<activity
 			android:name="com.tns.NativeScriptActivity"
 			android:label="@string/title_activity_kimera"
-			android:configChanges="keyboardHidden|orientation|screenSize"
+			android:configChanges="keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|locale|uiMode"
 			android:theme="@style/LaunchScreenTheme">
 
 			<meta-data android:name="SET_THEME_ON_LAUNCH" android:resource="@style/AppTheme" />

--- a/packages/template-master-detail-vue/app/App_Resources/Android/AndroidManifest.xml
+++ b/packages/template-master-detail-vue/app/App_Resources/Android/AndroidManifest.xml
@@ -28,7 +28,7 @@
 		<activity
 			android:name="com.tns.NativeScriptActivity"
 			android:label="@string/title_activity_kimera"
-			android:configChanges="keyboardHidden|orientation|screenSize"
+			android:configChanges="keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|locale|uiMode"
 			android:theme="@style/LaunchScreenTheme">
 
 			<meta-data android:name="SET_THEME_ON_LAUNCH" android:resource="@style/AppTheme" />

--- a/packages/template-master-detail/app/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-master-detail/app/App_Resources/Android/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
 		<activity
 			android:name="com.tns.NativeScriptActivity"
 			android:label="@string/title_activity_kimera"
-			android:configChanges="keyboardHidden|orientation|screenSize"
+			android:configChanges="keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|locale|uiMode"
 			android:theme="@style/LaunchScreenTheme">
 
 			<meta-data android:name="SET_THEME_ON_LAUNCH" android:resource="@style/AppTheme" />

--- a/packages/template-patient-care-ng/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-patient-care-ng/App_Resources/Android/src/main/AndroidManifest.xml
@@ -29,7 +29,7 @@
 		<activity
 			android:name="com.tns.NativeScriptActivity"
 			android:label="@string/title_activity_kimera"
-			android:configChanges="keyboardHidden|orientation|screenSize"
+			android:configChanges="keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|locale|uiMode"
 			android:theme="@style/LaunchScreenTheme">
 
 			<meta-data android:name="SET_THEME_ON_LAUNCH" android:resource="@style/AppTheme" />

--- a/packages/template-tab-navigation-ng/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-tab-navigation-ng/App_Resources/Android/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
 		<activity
 			android:name="com.tns.NativeScriptActivity"
 			android:label="@string/title_activity_kimera"
-			android:configChanges="keyboardHidden|orientation|screenSize"
+			android:configChanges="keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|locale|uiMode"
 			android:theme="@style/LaunchScreenTheme">
 
 			<meta-data android:name="SET_THEME_ON_LAUNCH" android:resource="@style/AppTheme" />

--- a/packages/template-tab-navigation-ts/app/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-tab-navigation-ts/app/App_Resources/Android/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
 		<activity
 			android:name="com.tns.NativeScriptActivity"
 			android:label="@string/title_activity_kimera"
-			android:configChanges="keyboardHidden|orientation|screenSize"
+			android:configChanges="keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|locale|uiMode"
 			android:theme="@style/LaunchScreenTheme">
 
 			<meta-data android:name="SET_THEME_ON_LAUNCH" android:resource="@style/AppTheme" />

--- a/packages/template-tab-navigation/app/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-tab-navigation/app/App_Resources/Android/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
 		<activity
 			android:name="com.tns.NativeScriptActivity"
 			android:label="@string/title_activity_kimera"
-			android:configChanges="keyboardHidden|orientation|screenSize"
+			android:configChanges="keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|locale|uiMode"
 			android:theme="@style/LaunchScreenTheme">
 
 			<meta-data android:name="SET_THEME_ON_LAUNCH" android:resource="@style/AppTheme" />


### PR DESCRIPTION
Extend activity [configuration changes list]  (https://developer.android.com/guide/topics/manifest/activity-element).

_Lists configuration changes that the activity will handle itself. When a configuration change occurs at runtime, the activity is shut down and restarted by default, but declaring a configuration with this attribute will prevent the activity from being restarted. Instead, the activity remains running and its onConfigurationChanged() method is called._

Originating from https://github.com/NativeScript/NativeScript/issues/6753