### PR TITLE
fix: after-createProject hook

### DIFF
--- a/packages/template-master-detail-kinvey-ts/hooks/after-createProject/after-createProject.js
+++ b/packages/template-master-detail-kinvey-ts/hooks/after-createProject/after-createProject.js
@@ -63,8 +63,8 @@ module.exports = function (hookArgs) {
     }
 
     function updateFirebaseConfigAppId(packageJson) {
-        const googleServicesJsonPath = path.join(appRootFolder, "App_Resources", "Android", "google-services.json");
-        const googleServiceInfoPlistPath = path.join(appRootFolder, "App_Resources", "iOS", "GoogleService-Info.plist");
+        const googleServicesJsonPath = path.join(appRootFolder, "app", "App_Resources", "Android", "google-services.json");
+        const googleServiceInfoPlistPath = path.join(appRootFolder, "app", "App_Resources", "iOS", "GoogleService-Info.plist");
 
         if (!packageJson.nativescript || !packageJson.nativescript.id) {
             return Promise.reject(new Error("cannot find nativescript node in package.json file"));

--- a/packages/template-master-detail-kinvey/hooks/after-createProject/after-createProject.js
+++ b/packages/template-master-detail-kinvey/hooks/after-createProject/after-createProject.js
@@ -63,8 +63,8 @@ module.exports = function (hookArgs) {
     }
 
     function updateFirebaseConfigAppId(packageJson) {
-        const googleServicesJsonPath = path.join(appRootFolder, "App_Resources", "Android", "google-services.json");
-        const googleServiceInfoPlistPath = path.join(appRootFolder, "App_Resources", "iOS", "GoogleService-Info.plist");
+        const googleServicesJsonPath = path.join(appRootFolder, "app", "App_Resources", "Android", "google-services.json");
+        const googleServiceInfoPlistPath = path.join(appRootFolder, "app", "App_Resources", "iOS", "GoogleService-Info.plist");
 
         if (!packageJson.nativescript || !packageJson.nativescript.id) {
             return Promise.reject(new Error("cannot find nativescript node in package.json file"));


### PR DESCRIPTION
Fixes after-createProject hook error in master-detail-kinvey & master-detail-kinvey-ts:
```
15:56:26 Execute command: C:\Git\nativescript-tooling-qa\node_modules\.bin\tns create master-detail-kinvey --template C:\Git\nativescript-tooling-qa\sut\template-master-detail-kinvey.tgz 
15:57:08 OUTPUT: 
{ [Error: ENOENT: no such file or directory, open 'C:\Git\nativescript-tooling-qa\master-detail-kinvey\App_Resources\Android\google-services.json']
  errno: -4058,
  code: 'ENOENT',
  syscall: 'open',
  path:
   'C:\\Git\\nativescript-tooling-qa\\master-detail-kinvey\\App_Resources\\Android\\google-services.json' }

Project master-detail-kinvey was successfully created.
```