### PR TITLE
fix: no-dimension listview in stacklayout warning

### DIFF
--- a/packages/template-hello-world-ng/src/app/item/items.component.html
+++ b/packages/template-hello-world-ng/src/app/item/items.component.html
@@ -14,20 +14,20 @@ http://docs.nativescript.org/ui/action-bar
 </ActionBar>
 
 <!--
-The StackLayout stacks UI components on the screen — either vertically or horizontally.
-In this case, the StackLayout does vertical stacking; you can change the stacking to
-horizontal by applying a orientation="horizontal" attribute to the <StackLayout> element.
+The GridLayout arranges its child elements in a table structure of rows and columns.
+A cell can contain multiple child elements, they can span over multiple rows and columns, 
+and even overlap each other. The GridLayout has one column and one row by default.
 You can learn more about NativeScript layouts at https://docs.nativescript.org/ui/layout-containers.
 
 These components make use of several CSS class names that are part of the NativeScript
 core theme, such as p-20, btn, h2, and list-group. You can view a full list of the
 class names available for styling your app at https://docs.nativescript.org/ui/theme.
 -->
-<StackLayout class="page">
+<GridLayout class="page">
     <ListView [items]="items" class="list-group">
         <ng-template let-item="item">
             <Label [nsRouterLink]="['/item', item.id]" [text]="item.name"
                 class="list-group-item"></Label>
         </ng-template>
     </ListView>
-</StackLayout>
+</GridLayout>


### PR DESCRIPTION
Fix no-dimension listview in stacklayout warning:
```
JS: Avoid using ListView or ScrollView with no explicit height set inside StackLayout. Doing so might results in poor user interface performance and a poor user experience.
```