### PR TITLE
Move minSdk from manifest to the gradle

### DIFF
--- a/packages/template-blank-ng/App_Resources/Android/app.gradle
+++ b/packages/template-blank-ng/App_Resources/Android/app.gradle
@@ -5,15 +5,16 @@
 //	implementation 'com.android.support:recyclerview-v7:+'
 //}
 
-// If you want to add something to be applied before applying plugins' include.gradle files 
+// If you want to add something to be applied before applying plugins' include.gradle files
 // e.g. project.ext.googlePlayServicesVersion = "15.0.1"
 // create a file named before-plugins.gradle in the current directory and place it there
 
-android {  
-  defaultConfig {  
+android {
+  defaultConfig {
+    minSdkVersion 17
     generatedDensities = []
-  }  
-  aaptOptions {  
-    additionalParameters "--no-version-vectors"  
-  }  
-} 
+  }
+  aaptOptions {
+    additionalParameters "--no-version-vectors"
+  }
+}

--- a/packages/template-blank-ng/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-blank-ng/App_Resources/Android/src/main/AndroidManifest.xml
@@ -10,10 +10,6 @@
 		android:largeScreens="true"
 		android:xlargeScreens="true"/>
 
-	<uses-sdk
-		android:minSdkVersion="17"
-		android:targetSdkVersion="__APILEVEL__"/>
-
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.INTERNET"/>

--- a/packages/template-blank-ts/app/App_Resources/Android/app.gradle
+++ b/packages/template-blank-ts/app/App_Resources/Android/app.gradle
@@ -5,15 +5,16 @@
 //	implementation 'com.android.support:recyclerview-v7:+'
 //}
 
-// If you want to add something to be applied before applying plugins' include.gradle files 
+// If you want to add something to be applied before applying plugins' include.gradle files
 // e.g. project.ext.googlePlayServicesVersion = "15.0.1"
 // create a file named before-plugins.gradle in the current directory and place it there
 
-android {  
-  defaultConfig {  
+android {
+  defaultConfig {
+    minSdkVersion 17
     generatedDensities = []
-  }  
-  aaptOptions {  
-    additionalParameters "--no-version-vectors"  
-  }  
-} 
+  }
+  aaptOptions {
+    additionalParameters "--no-version-vectors"
+  }
+}

--- a/packages/template-blank-ts/app/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-blank-ts/app/App_Resources/Android/src/main/AndroidManifest.xml
@@ -10,10 +10,6 @@
 		android:largeScreens="true"
 		android:xlargeScreens="true"/>
 
-	<uses-sdk
-		android:minSdkVersion="17"
-		android:targetSdkVersion="__APILEVEL__"/>
-
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.INTERNET"/>

--- a/packages/template-blank-vue/app/App_Resources/Android/AndroidManifest.xml
+++ b/packages/template-blank-vue/app/App_Resources/Android/AndroidManifest.xml
@@ -10,10 +10,6 @@
 		android:largeScreens="true"
 		android:xlargeScreens="true"/>
 
-	<uses-sdk
-		android:minSdkVersion="17"
-		android:targetSdkVersion="__APILEVEL__"/>
-
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.INTERNET"/>

--- a/packages/template-blank-vue/app/App_Resources/Android/app.gradle
+++ b/packages/template-blank-vue/app/App_Resources/Android/app.gradle
@@ -5,12 +5,13 @@
 //	implementation 'com.android.support:recyclerview-v7:+'
 //}
 
-// If you want to add something to be applied before applying plugins' include.gradle files 
+// If you want to add something to be applied before applying plugins' include.gradle files
 // e.g. project.ext.googlePlayServicesVersion = "15.0.1"
 // create a file named before-plugins.gradle in the current directory and place it there
 
 android {
   defaultConfig {
+    minSdkVersion 17
     generatedDensities = []
   }
   aaptOptions {

--- a/packages/template-blank/app/App_Resources/Android/app.gradle
+++ b/packages/template-blank/app/App_Resources/Android/app.gradle
@@ -5,15 +5,16 @@
 //	implementation 'com.android.support:recyclerview-v7:+'
 //}
 
-// If you want to add something to be applied before applying plugins' include.gradle files 
+// If you want to add something to be applied before applying plugins' include.gradle files
 // e.g. project.ext.googlePlayServicesVersion = "15.0.1"
 // create a file named before-plugins.gradle in the current directory and place it there
 
-android {  
-  defaultConfig {  
+android {
+  defaultConfig {
+    minSdkVersion 17
     generatedDensities = []
-  }  
-  aaptOptions {  
-    additionalParameters "--no-version-vectors"  
-  }  
-} 
+  }
+  aaptOptions {
+    additionalParameters "--no-version-vectors"
+  }
+}

--- a/packages/template-blank/app/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-blank/app/App_Resources/Android/src/main/AndroidManifest.xml
@@ -10,10 +10,6 @@
 		android:largeScreens="true"
 		android:xlargeScreens="true"/>
 
-	<uses-sdk
-		android:minSdkVersion="17"
-		android:targetSdkVersion="__APILEVEL__"/>
-
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.INTERNET"/>

--- a/packages/template-drawer-navigation-ng/App_Resources/Android/app.gradle
+++ b/packages/template-drawer-navigation-ng/App_Resources/Android/app.gradle
@@ -5,15 +5,16 @@
 //	implementation 'com.android.support:recyclerview-v7:+'
 //}
 
-// If you want to add something to be applied before applying plugins' include.gradle files 
+// If you want to add something to be applied before applying plugins' include.gradle files
 // e.g. project.ext.googlePlayServicesVersion = "15.0.1"
 // create a file named before-plugins.gradle in the current directory and place it there
 
-android {  
-  defaultConfig {  
+android {
+  defaultConfig {
+    minSdkVersion 17
     generatedDensities = []
-  }  
-  aaptOptions {  
-    additionalParameters "--no-version-vectors"  
-  }  
-} 
+  }
+  aaptOptions {
+    additionalParameters "--no-version-vectors"
+  }
+}

--- a/packages/template-drawer-navigation-ng/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-drawer-navigation-ng/App_Resources/Android/src/main/AndroidManifest.xml
@@ -10,10 +10,6 @@
 		android:largeScreens="true"
 		android:xlargeScreens="true"/>
 
-	<uses-sdk
-		android:minSdkVersion="17"
-		android:targetSdkVersion="__APILEVEL__"/>
-
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.INTERNET"/>

--- a/packages/template-drawer-navigation-ts/app/App_Resources/Android/app.gradle
+++ b/packages/template-drawer-navigation-ts/app/App_Resources/Android/app.gradle
@@ -5,15 +5,16 @@
 //	implementation 'com.android.support:recyclerview-v7:+'
 //}
 
-// If you want to add something to be applied before applying plugins' include.gradle files 
+// If you want to add something to be applied before applying plugins' include.gradle files
 // e.g. project.ext.googlePlayServicesVersion = "15.0.1"
 // create a file named before-plugins.gradle in the current directory and place it there
 
-android {  
-  defaultConfig {  
+android {
+  defaultConfig {
+    minSdkVersion 17
     generatedDensities = []
-  }  
-  aaptOptions {  
-    additionalParameters "--no-version-vectors"  
-  }  
-} 
+  }
+  aaptOptions {
+    additionalParameters "--no-version-vectors"
+  }
+}

--- a/packages/template-drawer-navigation-ts/app/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-drawer-navigation-ts/app/App_Resources/Android/src/main/AndroidManifest.xml
@@ -10,10 +10,6 @@
 		android:largeScreens="true"
 		android:xlargeScreens="true"/>
 
-	<uses-sdk
-		android:minSdkVersion="17"
-		android:targetSdkVersion="__APILEVEL__"/>
-
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.INTERNET"/>

--- a/packages/template-drawer-navigation/app/App_Resources/Android/app.gradle
+++ b/packages/template-drawer-navigation/app/App_Resources/Android/app.gradle
@@ -5,15 +5,16 @@
 //	implementation 'com.android.support:recyclerview-v7:+'
 //}
 
-// If you want to add something to be applied before applying plugins' include.gradle files 
+// If you want to add something to be applied before applying plugins' include.gradle files
 // e.g. project.ext.googlePlayServicesVersion = "15.0.1"
 // create a file named before-plugins.gradle in the current directory and place it there
 
-android {  
-  defaultConfig {  
+android {
+  defaultConfig {
+    minSdkVersion 17
     generatedDensities = []
-  }  
-  aaptOptions {  
-    additionalParameters "--no-version-vectors"  
-  }  
-} 
+  }
+  aaptOptions {
+    additionalParameters "--no-version-vectors"
+  }
+}

--- a/packages/template-drawer-navigation/app/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-drawer-navigation/app/App_Resources/Android/src/main/AndroidManifest.xml
@@ -10,10 +10,6 @@
 		android:largeScreens="true"
 		android:xlargeScreens="true"/>
 
-	<uses-sdk
-		android:minSdkVersion="17"
-		android:targetSdkVersion="__APILEVEL__"/>
-
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.INTERNET"/>

--- a/packages/template-enterprise-auth-ng/App_Resources/Android/app.gradle
+++ b/packages/template-enterprise-auth-ng/App_Resources/Android/app.gradle
@@ -5,15 +5,16 @@
 //	implementation 'com.android.support:recyclerview-v7:+'
 //}
 
-// If you want to add something to be applied before applying plugins' include.gradle files 
+// If you want to add something to be applied before applying plugins' include.gradle files
 // e.g. project.ext.googlePlayServicesVersion = "15.0.1"
 // create a file named before-plugins.gradle in the current directory and place it there
 
-android {  
-  defaultConfig {  
+android {
+  defaultConfig {
+    minSdkVersion 17
     generatedDensities = []
-  }  
-  aaptOptions {  
-    additionalParameters "--no-version-vectors"  
-  }  
-} 
+  }
+  aaptOptions {
+    additionalParameters "--no-version-vectors"
+  }
+}

--- a/packages/template-enterprise-auth-ng/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-enterprise-auth-ng/App_Resources/Android/src/main/AndroidManifest.xml
@@ -10,10 +10,6 @@
 		android:largeScreens="true"
 		android:xlargeScreens="true"/>
 
-	<uses-sdk
-		android:minSdkVersion="21"
-		android:targetSdkVersion="__APILEVEL__"/>
-
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.INTERNET"/>

--- a/packages/template-enterprise-auth-ts/app/App_Resources/Android/app.gradle
+++ b/packages/template-enterprise-auth-ts/app/App_Resources/Android/app.gradle
@@ -5,15 +5,16 @@
 //	implementation 'com.android.support:recyclerview-v7:+'
 //}
 
-// If you want to add something to be applied before applying plugins' include.gradle files 
+// If you want to add something to be applied before applying plugins' include.gradle files
 // e.g. project.ext.googlePlayServicesVersion = "15.0.1"
 // create a file named before-plugins.gradle in the current directory and place it there
 
-android {  
-  defaultConfig {  
+android {
+  defaultConfig {
+    minSdkVersion 17
     generatedDensities = []
-  }  
-  aaptOptions {  
-    additionalParameters "--no-version-vectors"  
-  }  
-} 
+  }
+  aaptOptions {
+    additionalParameters "--no-version-vectors"
+  }
+}

--- a/packages/template-enterprise-auth-ts/app/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-enterprise-auth-ts/app/App_Resources/Android/src/main/AndroidManifest.xml
@@ -10,10 +10,6 @@
 		android:largeScreens="true"
 		android:xlargeScreens="true"/>
 
-	<uses-sdk
-		android:minSdkVersion="21"
-		android:targetSdkVersion="__APILEVEL__"/>
-
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.INTERNET"/>

--- a/packages/template-enterprise-auth/app/App_Resources/Android/app.gradle
+++ b/packages/template-enterprise-auth/app/App_Resources/Android/app.gradle
@@ -5,15 +5,16 @@
 //	implementation 'com.android.support:recyclerview-v7:+'
 //}
 
-// If you want to add something to be applied before applying plugins' include.gradle files 
+// If you want to add something to be applied before applying plugins' include.gradle files
 // e.g. project.ext.googlePlayServicesVersion = "15.0.1"
 // create a file named before-plugins.gradle in the current directory and place it there
 
-android {  
-  defaultConfig {  
+android {
+  defaultConfig {
+    minSdkVersion 17
     generatedDensities = []
-  }  
-  aaptOptions {  
-    additionalParameters "--no-version-vectors"  
-  }  
-} 
+  }
+  aaptOptions {
+    additionalParameters "--no-version-vectors"
+  }
+}

--- a/packages/template-enterprise-auth/app/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-enterprise-auth/app/App_Resources/Android/src/main/AndroidManifest.xml
@@ -10,10 +10,6 @@
 		android:largeScreens="true"
 		android:xlargeScreens="true"/>
 
-	<uses-sdk
-		android:minSdkVersion="21"
-		android:targetSdkVersion="__APILEVEL__"/>
-
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.INTERNET"/>

--- a/packages/template-health-survey-ng/App_Resources/Android/app.gradle
+++ b/packages/template-health-survey-ng/App_Resources/Android/app.gradle
@@ -5,15 +5,16 @@
 //	implementation 'com.android.support:recyclerview-v7:+'
 //}
 
-// If you want to add something to be applied before applying plugins' include.gradle files 
+// If you want to add something to be applied before applying plugins' include.gradle files
 // e.g. project.ext.googlePlayServicesVersion = "15.0.1"
 // create a file named before-plugins.gradle in the current directory and place it there
 
-android {  
-  defaultConfig {  
+android {
+  defaultConfig {
+    minSdkVersion 17
     generatedDensities = []
-  }  
-  aaptOptions {  
-    additionalParameters "--no-version-vectors"  
-  }  
-} 
+  }
+  aaptOptions {
+    additionalParameters "--no-version-vectors"
+  }
+}

--- a/packages/template-health-survey-ng/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-health-survey-ng/App_Resources/Android/src/main/AndroidManifest.xml
@@ -10,10 +10,6 @@
 		android:largeScreens="true"
 		android:xlargeScreens="true"/>
 
-	<uses-sdk
-		android:minSdkVersion="21"
-		android:targetSdkVersion="__APILEVEL__"/>
-
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.INTERNET"/>

--- a/packages/template-hello-world-ng/App_Resources/Android/app.gradle
+++ b/packages/template-hello-world-ng/App_Resources/Android/app.gradle
@@ -5,15 +5,16 @@
 //	implementation 'com.android.support:recyclerview-v7:+'
 //}
 
-// If you want to add something to be applied before applying plugins' include.gradle files 
+// If you want to add something to be applied before applying plugins' include.gradle files
 // e.g. project.ext.googlePlayServicesVersion = "15.0.1"
 // create a file named before-plugins.gradle in the current directory and place it there
- 
-android {  
-  defaultConfig {  
+
+android {
+  defaultConfig {
+    minSdkVersion 17
     generatedDensities = []
-  }  
-  aaptOptions {  
-    additionalParameters "--no-version-vectors"  
-  }  
-} 
+  }
+  aaptOptions {
+    additionalParameters "--no-version-vectors"
+  }
+}

--- a/packages/template-hello-world-ng/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-hello-world-ng/App_Resources/Android/src/main/AndroidManifest.xml
@@ -10,10 +10,6 @@
 		android:largeScreens="true"
 		android:xlargeScreens="true"/>
 
-	<uses-sdk
-		android:minSdkVersion="17"
-		android:targetSdkVersion="__APILEVEL__"/>
-
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.INTERNET"/>

--- a/packages/template-hello-world-ts/app/App_Resources/Android/app.gradle
+++ b/packages/template-hello-world-ts/app/App_Resources/Android/app.gradle
@@ -5,15 +5,16 @@
 //	implementation 'com.android.support:recyclerview-v7:+'
 //}
 
-// If you want to add something to be applied before applying plugins' include.gradle files 
+// If you want to add something to be applied before applying plugins' include.gradle files
 // e.g. project.ext.googlePlayServicesVersion = "15.0.1"
 // create a file named before-plugins.gradle in the current directory and place it there
 
-android {  
-  defaultConfig {  
+android {
+  defaultConfig {
+    minSdkVersion 17
     generatedDensities = []
-  }  
-  aaptOptions {  
-    additionalParameters "--no-version-vectors"  
-  }  
-} 
+  }
+  aaptOptions {
+    additionalParameters "--no-version-vectors"
+  }
+}

--- a/packages/template-hello-world-ts/app/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-hello-world-ts/app/App_Resources/Android/src/main/AndroidManifest.xml
@@ -10,10 +10,6 @@
 		android:largeScreens="true"
 		android:xlargeScreens="true"/>
 
-	<uses-sdk
-		android:minSdkVersion="17"
-		android:targetSdkVersion="__APILEVEL__"/>
-
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.INTERNET"/>

--- a/packages/template-hello-world/app/App_Resources/Android/app.gradle
+++ b/packages/template-hello-world/app/App_Resources/Android/app.gradle
@@ -5,15 +5,16 @@
 //	implementation 'com.android.support:recyclerview-v7:+'
 //}
 
-// If you want to add something to be applied before applying plugins' include.gradle files 
+// If you want to add something to be applied before applying plugins' include.gradle files
 // e.g. project.ext.googlePlayServicesVersion = "15.0.1"
 // create a file named before-plugins.gradle in the current directory and place it there
 
-android {  
-  defaultConfig {  
+android {
+  defaultConfig {
+    minSdkVersion 17
     generatedDensities = []
-  }  
-  aaptOptions {  
-    additionalParameters "--no-version-vectors"  
-  }  
-} 
+  }
+  aaptOptions {
+    additionalParameters "--no-version-vectors"
+  }
+}

--- a/packages/template-hello-world/app/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-hello-world/app/App_Resources/Android/src/main/AndroidManifest.xml
@@ -10,10 +10,6 @@
 		android:largeScreens="true"
 		android:xlargeScreens="true"/>
 
-	<uses-sdk
-		android:minSdkVersion="17"
-		android:targetSdkVersion="__APILEVEL__"/>
-
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.INTERNET"/>

--- a/packages/template-master-detail-kinvey-ng/App_Resources/Android/app.gradle
+++ b/packages/template-master-detail-kinvey-ng/App_Resources/Android/app.gradle
@@ -5,15 +5,16 @@
 //	implementation 'com.android.support:recyclerview-v7:+'
 //}
 
-// If you want to add something to be applied before applying plugins' include.gradle files 
+// If you want to add something to be applied before applying plugins' include.gradle files
 // e.g. project.ext.googlePlayServicesVersion = "15.0.1"
 // create a file named before-plugins.gradle in the current directory and place it there
 
-android {  
-  defaultConfig {  
+android {
+  defaultConfig {
+    minSdkVersion 17
     generatedDensities = []
-  }  
-  aaptOptions {  
-    additionalParameters "--no-version-vectors"  
-  }  
-} 
+  }
+  aaptOptions {
+    additionalParameters "--no-version-vectors"
+  }
+}

--- a/packages/template-master-detail-kinvey-ng/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-master-detail-kinvey-ng/App_Resources/Android/src/main/AndroidManifest.xml
@@ -10,10 +10,6 @@
 		android:largeScreens="true"
 		android:xlargeScreens="true"/>
 
-	<uses-sdk
-		android:minSdkVersion="21"
-		android:targetSdkVersion="__APILEVEL__"/>
-
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.INTERNET"/>

--- a/packages/template-master-detail-kinvey-ts/app/App_Resources/Android/app.gradle
+++ b/packages/template-master-detail-kinvey-ts/app/App_Resources/Android/app.gradle
@@ -5,15 +5,16 @@
 //	implementation 'com.android.support:recyclerview-v7:+'
 //}
 
-// If you want to add something to be applied before applying plugins' include.gradle files 
+// If you want to add something to be applied before applying plugins' include.gradle files
 // e.g. project.ext.googlePlayServicesVersion = "15.0.1"
 // create a file named before-plugins.gradle in the current directory and place it there
 
-android {  
-  defaultConfig {  
+android {
+  defaultConfig {
+    minSdkVersion 17
     generatedDensities = []
-  }  
-  aaptOptions {  
-    additionalParameters "--no-version-vectors"  
-  }  
-} 
+  }
+  aaptOptions {
+    additionalParameters "--no-version-vectors"
+  }
+}

--- a/packages/template-master-detail-kinvey-ts/app/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-master-detail-kinvey-ts/app/App_Resources/Android/src/main/AndroidManifest.xml
@@ -10,10 +10,6 @@
 		android:largeScreens="true"
 		android:xlargeScreens="true"/>
 
-	<uses-sdk
-		android:minSdkVersion="21"
-		android:targetSdkVersion="__APILEVEL__"/>
-
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.INTERNET"/>

--- a/packages/template-master-detail-kinvey/app/App_Resources/Android/app.gradle
+++ b/packages/template-master-detail-kinvey/app/App_Resources/Android/app.gradle
@@ -5,15 +5,16 @@
 //	implementation 'com.android.support:recyclerview-v7:+'
 //}
 
-// If you want to add something to be applied before applying plugins' include.gradle files 
+// If you want to add something to be applied before applying plugins' include.gradle files
 // e.g. project.ext.googlePlayServicesVersion = "15.0.1"
 // create a file named before-plugins.gradle in the current directory and place it there
 
-android {  
-  defaultConfig {  
+android {
+  defaultConfig {
+    minSdkVersion 17
     generatedDensities = []
-  }  
-  aaptOptions {  
-    additionalParameters "--no-version-vectors"  
-  }  
-} 
+  }
+  aaptOptions {
+    additionalParameters "--no-version-vectors"
+  }
+}

--- a/packages/template-master-detail-kinvey/app/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-master-detail-kinvey/app/App_Resources/Android/src/main/AndroidManifest.xml
@@ -10,10 +10,6 @@
 		android:largeScreens="true"
 		android:xlargeScreens="true"/>
 
-	<uses-sdk
-		android:minSdkVersion="21"
-		android:targetSdkVersion="__APILEVEL__"/>
-
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.INTERNET"/>

--- a/packages/template-master-detail-ng/App_Resources/Android/app.gradle
+++ b/packages/template-master-detail-ng/App_Resources/Android/app.gradle
@@ -5,15 +5,16 @@
 //	implementation 'com.android.support:recyclerview-v7:+'
 //}
 
-// If you want to add something to be applied before applying plugins' include.gradle files 
+// If you want to add something to be applied before applying plugins' include.gradle files
 // e.g. project.ext.googlePlayServicesVersion = "15.0.1"
 // create a file named before-plugins.gradle in the current directory and place it there
 
-android {  
-  defaultConfig {  
+android {
+  defaultConfig {
+    minSdkVersion 17
     generatedDensities = []
-  }  
-  aaptOptions {  
-    additionalParameters "--no-version-vectors"  
-  }  
-} 
+  }
+  aaptOptions {
+    additionalParameters "--no-version-vectors"
+  }
+}

--- a/packages/template-master-detail-ng/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-master-detail-ng/App_Resources/Android/src/main/AndroidManifest.xml
@@ -10,10 +10,6 @@
 		android:largeScreens="true"
 		android:xlargeScreens="true"/>
 
-	<uses-sdk
-		android:minSdkVersion="17"
-		android:targetSdkVersion="__APILEVEL__"/>
-
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.INTERNET"/>

--- a/packages/template-master-detail-ts/app/App_Resources/Android/app.gradle
+++ b/packages/template-master-detail-ts/app/App_Resources/Android/app.gradle
@@ -5,15 +5,16 @@
 //	implementation 'com.android.support:recyclerview-v7:+'
 //}
 
-// If you want to add something to be applied before applying plugins' include.gradle files 
+// If you want to add something to be applied before applying plugins' include.gradle files
 // e.g. project.ext.googlePlayServicesVersion = "15.0.1"
 // create a file named before-plugins.gradle in the current directory and place it there
 
-android {  
-  defaultConfig {  
+android {
+  defaultConfig {
+    minSdkVersion 17
     generatedDensities = []
-  }  
-  aaptOptions {  
-    additionalParameters "--no-version-vectors"  
-  }  
-} 
+  }
+  aaptOptions {
+    additionalParameters "--no-version-vectors"
+  }
+}

--- a/packages/template-master-detail-ts/app/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-master-detail-ts/app/App_Resources/Android/src/main/AndroidManifest.xml
@@ -10,10 +10,6 @@
 		android:largeScreens="true"
 		android:xlargeScreens="true"/>
 
-	<uses-sdk
-		android:minSdkVersion="17"
-		android:targetSdkVersion="__APILEVEL__"/>
-
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.INTERNET"/>

--- a/packages/template-master-detail-vue/app/App_Resources/Android/AndroidManifest.xml
+++ b/packages/template-master-detail-vue/app/App_Resources/Android/AndroidManifest.xml
@@ -10,10 +10,6 @@
 		android:largeScreens="true"
 		android:xlargeScreens="true"/>
 
-	<uses-sdk
-		android:minSdkVersion="17"
-		android:targetSdkVersion="__APILEVEL__"/>
-
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.INTERNET"/>

--- a/packages/template-master-detail-vue/app/App_Resources/Android/app.gradle
+++ b/packages/template-master-detail-vue/app/App_Resources/Android/app.gradle
@@ -5,12 +5,13 @@
 //	implementation 'com.android.support:recyclerview-v7:+'
 //}
 
-// If you want to add something to be applied before applying plugins' include.gradle files 
+// If you want to add something to be applied before applying plugins' include.gradle files
 // e.g. project.ext.googlePlayServicesVersion = "15.0.1"
 // create a file named before-plugins.gradle in the current directory and place it there
 
 android {
   defaultConfig {
+    minSdkVersion 17
     generatedDensities = []
   }
   aaptOptions {

--- a/packages/template-master-detail/app/App_Resources/Android/app.gradle
+++ b/packages/template-master-detail/app/App_Resources/Android/app.gradle
@@ -5,15 +5,16 @@
 //	implementation 'com.android.support:recyclerview-v7:+'
 //}
 
-// If you want to add something to be applied before applying plugins' include.gradle files 
+// If you want to add something to be applied before applying plugins' include.gradle files
 // e.g. project.ext.googlePlayServicesVersion = "15.0.1"
 // create a file named before-plugins.gradle in the current directory and place it there
 
-android {  
-  defaultConfig {  
+android {
+  defaultConfig {
+    minSdkVersion 17
     generatedDensities = []
-  }  
-  aaptOptions {  
-    additionalParameters "--no-version-vectors"  
-  }  
-} 
+  }
+  aaptOptions {
+    additionalParameters "--no-version-vectors"
+  }
+}

--- a/packages/template-master-detail/app/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-master-detail/app/App_Resources/Android/src/main/AndroidManifest.xml
@@ -10,10 +10,6 @@
 		android:largeScreens="true"
 		android:xlargeScreens="true"/>
 
-	<uses-sdk
-		android:minSdkVersion="17"
-		android:targetSdkVersion="__APILEVEL__"/>
-
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.INTERNET"/>

--- a/packages/template-patient-care-ng/App_Resources/Android/app.gradle
+++ b/packages/template-patient-care-ng/App_Resources/Android/app.gradle
@@ -5,15 +5,16 @@
 //	implementation 'com.android.support:recyclerview-v7:+'
 //}
 
-// If you want to add something to be applied before applying plugins' include.gradle files 
+// If you want to add something to be applied before applying plugins' include.gradle files
 // e.g. project.ext.googlePlayServicesVersion = "15.0.1"
 // create a file named before-plugins.gradle in the current directory and place it there
 
-android {  
-  defaultConfig {  
+android {
+  defaultConfig {
+    minSdkVersion 17
     generatedDensities = []
-  }  
-  aaptOptions {  
-    additionalParameters "--no-version-vectors"  
-  }  
-} 
+  }
+  aaptOptions {
+    additionalParameters "--no-version-vectors"
+  }
+}

--- a/packages/template-patient-care-ng/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-patient-care-ng/App_Resources/Android/src/main/AndroidManifest.xml
@@ -10,10 +10,6 @@
 		android:largeScreens="true"
 		android:xlargeScreens="true"/>
 
-	<uses-sdk
-		android:minSdkVersion="21"
-		android:targetSdkVersion="__APILEVEL__"/>
-
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.INTERNET"/>

--- a/packages/template-tab-navigation-ng/App_Resources/Android/app.gradle
+++ b/packages/template-tab-navigation-ng/App_Resources/Android/app.gradle
@@ -5,15 +5,16 @@
 //	implementation 'com.android.support:recyclerview-v7:+'
 //}
 
-// If you want to add something to be applied before applying plugins' include.gradle files 
+// If you want to add something to be applied before applying plugins' include.gradle files
 // e.g. project.ext.googlePlayServicesVersion = "15.0.1"
 // create a file named before-plugins.gradle in the current directory and place it there
 
-android {  
-  defaultConfig {  
+android {
+  defaultConfig {
+    minSdkVersion 17
     generatedDensities = []
-  }  
-  aaptOptions {  
-    additionalParameters "--no-version-vectors"  
-  }  
-} 
+  }
+  aaptOptions {
+    additionalParameters "--no-version-vectors"
+  }
+}

--- a/packages/template-tab-navigation-ng/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-tab-navigation-ng/App_Resources/Android/src/main/AndroidManifest.xml
@@ -10,10 +10,6 @@
 		android:largeScreens="true"
 		android:xlargeScreens="true"/>
 
-	<uses-sdk
-		android:minSdkVersion="17"
-		android:targetSdkVersion="__APILEVEL__"/>
-
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.INTERNET"/>

--- a/packages/template-tab-navigation-ts/app/App_Resources/Android/app.gradle
+++ b/packages/template-tab-navigation-ts/app/App_Resources/Android/app.gradle
@@ -5,15 +5,16 @@
 //	implementation 'com.android.support:recyclerview-v7:+'
 //}
 
-// If you want to add something to be applied before applying plugins' include.gradle files 
+// If you want to add something to be applied before applying plugins' include.gradle files
 // e.g. project.ext.googlePlayServicesVersion = "15.0.1"
 // create a file named before-plugins.gradle in the current directory and place it there
 
-android {  
-  defaultConfig {  
+android {
+  defaultConfig {
+    minSdkVersion 17
     generatedDensities = []
-  }  
-  aaptOptions {  
-    additionalParameters "--no-version-vectors"  
-  }  
-} 
+  }
+  aaptOptions {
+    additionalParameters "--no-version-vectors"
+  }
+}

--- a/packages/template-tab-navigation-ts/app/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-tab-navigation-ts/app/App_Resources/Android/src/main/AndroidManifest.xml
@@ -10,10 +10,6 @@
 		android:largeScreens="true"
 		android:xlargeScreens="true"/>
 
-	<uses-sdk
-		android:minSdkVersion="17"
-		android:targetSdkVersion="__APILEVEL__"/>
-
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.INTERNET"/>

--- a/packages/template-tab-navigation/app/App_Resources/Android/app.gradle
+++ b/packages/template-tab-navigation/app/App_Resources/Android/app.gradle
@@ -5,15 +5,16 @@
 //	implementation 'com.android.support:recyclerview-v7:+'
 //}
 
-// If you want to add something to be applied before applying plugins' include.gradle files 
+// If you want to add something to be applied before applying plugins' include.gradle files
 // e.g. project.ext.googlePlayServicesVersion = "15.0.1"
 // create a file named before-plugins.gradle in the current directory and place it there
 
-android {  
-  defaultConfig {  
+android {
+  defaultConfig {
+    minSdkVersion 17
     generatedDensities = []
-  }  
-  aaptOptions {  
-    additionalParameters "--no-version-vectors"  
-  }  
-} 
+  }
+  aaptOptions {
+    additionalParameters "--no-version-vectors"
+  }
+}

--- a/packages/template-tab-navigation/app/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/packages/template-tab-navigation/app/App_Resources/Android/src/main/AndroidManifest.xml
@@ -10,10 +10,6 @@
 		android:largeScreens="true"
 		android:xlargeScreens="true"/>
 
-	<uses-sdk
-		android:minSdkVersion="17"
-		android:targetSdkVersion="__APILEVEL__"/>
-
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.INTERNET"/>


### PR DESCRIPTION
Related to https://github.com/NativeScript/android-runtime/issues/1316.
The **minSdkVersion** now is set through the **app.gradle** file and remove from the manifest to avoid errors in Android Studio.