### PR TITLE
chore: bump nativescript-vue version

### DIFF
--- a/packages/template-blank-vue/package.json
+++ b/packages/template-blank-vue/package.json
@@ -39,7 +39,7 @@
   ],
   "dependencies": {
     "nativescript-theme-core": "~1.0.4",
-    "nativescript-vue": "~2.0.0",
+    "nativescript-vue": "~2.2.0",
     "tns-core-modules": "~5.2.0"
   },
   "devDependencies": {
@@ -47,7 +47,7 @@
     "@babel/preset-env": "~7.1.0",
     "babel-loader": "~8.0.0",
     "nativescript-dev-webpack": "~0.20.0",
-    "nativescript-vue-template-compiler": "~2.0.0",
+    "nativescript-vue-template-compiler": "~2.2.0",
     "node-sass": "~4.9.0",
     "vue-loader": "~15.4.0"
   }

--- a/packages/template-master-detail-vue/package.json
+++ b/packages/template-master-detail-vue/package.json
@@ -42,7 +42,7 @@
     "nativescript-plugin-firebase": "~7.7.0",
     "nativescript-theme-core": "~1.0.4",
     "nativescript-ui-listview": "~5.1.0",
-    "nativescript-vue": "~2.0.0",
+    "nativescript-vue": "~2.2.0",
     "tns-core-modules": "~5.2.0"
   },
   "devDependencies": {
@@ -50,7 +50,7 @@
     "@babel/preset-env": "~7.1.0",
     "babel-loader": "~8.0.0",
     "nativescript-dev-webpack": "~0.20.0",
-    "nativescript-vue-template-compiler": "~2.0.0",
+    "nativescript-vue-template-compiler": "~2.2.0",
     "node-sass": "~4.9.0",
     "vue-loader": "~15.4.0"
   }


### PR DESCRIPTION
Bump to nativescript-vue@2.2

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.

## What is the current behavior?
Templates use nativescript-vue@2.0

## What is the new behavior?
Bump to nativescript-vue@2.2