### PR TITLE
chore: add deprecation tslint rule

### DIFF
--- a/packages/template-drawer-navigation-ng/tslint.json
+++ b/packages/template-drawer-navigation-ng/tslint.json
@@ -12,6 +12,7 @@
     "array-type": [true, "generic"],
     "arrow-return-shorthand": true,
     "component-class-suffix": true,
+    "deprecation": true,
     "directive-class-suffix": true,
     "member-access": [true, "no-public"],
     "newline-before-return": true,

--- a/packages/template-drawer-navigation-ts/tslint.json
+++ b/packages/template-drawer-navigation-ts/tslint.json
@@ -8,6 +8,7 @@
   "rules": {
     "array-type": [true, "generic"],
     "arrow-return-shorthand": true,
+    "deprecation": true,
     "member-access": [true, "no-public"],
     "newline-before-return": true,
     "no-angle-bracket-type-assertion": false,

--- a/packages/template-enterprise-auth-ng/tslint.json
+++ b/packages/template-enterprise-auth-ng/tslint.json
@@ -12,6 +12,7 @@
     "array-type": [true, "generic"],
     "arrow-return-shorthand": true,
     "component-class-suffix": true,
+    "deprecation": true,
     "directive-class-suffix": true,
     "member-access": [true, "no-public"],
     "newline-before-return": true,

--- a/packages/template-enterprise-auth-ts/tslint.json
+++ b/packages/template-enterprise-auth-ts/tslint.json
@@ -8,6 +8,7 @@
   "rules": {
     "array-type": [true, "generic"],
     "arrow-return-shorthand": true,
+    "deprecation": true,
     "member-access": [true, "no-public"],
     "newline-before-return": true,
     "no-angle-bracket-type-assertion": false,

--- a/packages/template-health-survey-ng/tslint.json
+++ b/packages/template-health-survey-ng/tslint.json
@@ -12,6 +12,7 @@
     "array-type": [true, "generic"],
     "arrow-return-shorthand": true,
     "component-class-suffix": true,
+    "deprecation": true,
     "directive-class-suffix": true,
     "member-access": [true, "no-public"],
     "newline-before-return": true,

--- a/packages/template-master-detail-kinvey-ng/tslint.json
+++ b/packages/template-master-detail-kinvey-ng/tslint.json
@@ -12,6 +12,7 @@
     "array-type": [true, "generic"],
     "arrow-return-shorthand": true,
     "component-class-suffix": true,
+    "deprecation": true,
     "directive-class-suffix": true,
     "member-access": [true, "no-public"],
     "newline-before-return": true,

--- a/packages/template-master-detail-kinvey-ts/tslint.json
+++ b/packages/template-master-detail-kinvey-ts/tslint.json
@@ -8,6 +8,7 @@
   "rules": {
     "array-type": [true, "generic"],
     "arrow-return-shorthand": true,
+    "deprecation": true,
     "member-access": [true, "no-public"],
     "newline-before-return": true,
     "no-angle-bracket-type-assertion": false,

--- a/packages/template-master-detail-ng/tslint.json
+++ b/packages/template-master-detail-ng/tslint.json
@@ -12,6 +12,7 @@
     "array-type": [true, "generic"],
     "arrow-return-shorthand": true,
     "component-class-suffix": true,
+    "deprecation": true,
     "directive-class-suffix": true,
     "member-access": [true, "no-public"],
     "newline-before-return": true,

--- a/packages/template-master-detail-ts/tslint.json
+++ b/packages/template-master-detail-ts/tslint.json
@@ -8,6 +8,7 @@
   "rules": {
     "array-type": [true, "generic"],
     "arrow-return-shorthand": true,
+    "deprecation": true,
     "member-access": [true, "no-public"],
     "newline-before-return": true,
     "no-angle-bracket-type-assertion": false,

--- a/packages/template-patient-care-ng/tslint.json
+++ b/packages/template-patient-care-ng/tslint.json
@@ -12,6 +12,7 @@
       "array-type": [true, "generic"],
       "arrow-return-shorthand": true,
       "component-class-suffix": true,
+      "deprecation": true,
       "directive-class-suffix": true,
       "member-access": [true, "no-public"],
       "newline-before-return": true,
@@ -55,4 +56,3 @@
       ]
     }
   }
-  

--- a/packages/template-tab-navigation-ng/tslint.json
+++ b/packages/template-tab-navigation-ng/tslint.json
@@ -12,6 +12,7 @@
     "array-type": [true, "generic"],
     "arrow-return-shorthand": true,
     "component-class-suffix": true,
+    "deprecation": true,
     "directive-class-suffix": true,
     "member-access": [true, "no-public"],
     "newline-before-return": true,

--- a/packages/template-tab-navigation-ts/tslint.json
+++ b/packages/template-tab-navigation-ts/tslint.json
@@ -8,6 +8,7 @@
   "rules": {
     "array-type": [true, "generic"],
     "arrow-return-shorthand": true,
+    "deprecation": true,
     "member-access": [true, "no-public"],
     "newline-before-return": true,
     "no-angle-bracket-type-assertion": false,


### PR DESCRIPTION
Warn when deprecated APIs are used for TypeScript/Angular flavors.