### PR TITLE
chore: remove schematics dev dependency

### DIFF
--- a/packages/template-blank-ng/package.json
+++ b/packages/template-blank-ng/package.json
@@ -53,7 +53,6 @@
   },
   "devDependencies": {
     "@angular/compiler-cli": "~8.0.0",
-    "@nativescript/schematics": "~0.6.0",
     "@ngtools/webpack": "~8.0.0",
     "nativescript-dev-typescript": "~0.10.0",
     "nativescript-dev-webpack": "~0.24.0"

--- a/packages/template-drawer-navigation-ng/package.json
+++ b/packages/template-drawer-navigation-ng/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@angular/compiler-cli": "~8.0.0",
-    "@nativescript/schematics": "~0.6.0",
     "@ngtools/webpack": "~8.0.0",
     "codelyzer": "~4.5.0",
     "nativescript-dev-sass": "~1.7.0",

--- a/packages/template-enterprise-auth-ng/package.json
+++ b/packages/template-enterprise-auth-ng/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@angular/compiler-cli": "~8.0.0",
-    "@nativescript/schematics": "~0.6.0",
     "@ngtools/webpack": "~8.0.0",
     "codelyzer": "~4.5.0",
     "nativescript-dev-typescript": "~0.10.0",

--- a/packages/template-health-survey-ng/package.json
+++ b/packages/template-health-survey-ng/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@angular/compiler-cli": "~8.0.0",
-    "@nativescript/schematics": "~0.6.0",
     "@ngtools/webpack": "~8.0.0",
     "codelyzer": "~4.5.0",
     "nativescript-dev-typescript": "~0.10.0",

--- a/packages/template-hello-world-ng/package.json
+++ b/packages/template-hello-world-ng/package.json
@@ -51,7 +51,6 @@
   },
   "devDependencies": {
     "@angular/compiler-cli": "~8.0.0",
-    "@nativescript/schematics": "~0.6.0",
     "@ngtools/webpack": "~8.0.0",
     "nativescript-dev-typescript": "~0.10.0",
     "nativescript-dev-webpack": "~0.24.0"

--- a/packages/template-master-detail-kinvey-ng/package.json
+++ b/packages/template-master-detail-kinvey-ng/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@angular/compiler-cli": "~8.0.0",
-    "@nativescript/schematics": "~0.6.0",
     "@ngtools/webpack": "~8.0.0",
     "codelyzer": "~4.5.0",
     "nativescript-dev-sass": "~1.7.0",

--- a/packages/template-master-detail-ng/package.json
+++ b/packages/template-master-detail-ng/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@angular/compiler-cli": "~8.0.0",
-    "@nativescript/schematics": "~0.6.0",
     "@ngtools/webpack": "~8.0.0",
     "codelyzer": "~4.5.0",
     "nativescript-dev-sass": "~1.7.0",

--- a/packages/template-patient-care-ng/package.json
+++ b/packages/template-patient-care-ng/package.json
@@ -63,7 +63,6 @@
   },
   "devDependencies": {
     "@angular/compiler-cli": "~8.0.0",
-    "@nativescript/schematics": "~0.6.0",
     "@ngtools/webpack": "~8.0.0",
     "codelyzer": "~4.5.0",
     "nativescript-dev-typescript": "~0.10.0",

--- a/packages/template-tab-navigation-ng/package.json
+++ b/packages/template-tab-navigation-ng/package.json
@@ -59,7 +59,6 @@
   },
   "devDependencies": {
     "@angular/compiler-cli": "~8.0.0",
-    "@nativescript/schematics": "~0.6.0",
     "@ngtools/webpack": "~8.0.0",
     "codelyzer": "~4.5.0",
     "nativescript-dev-sass": "~1.7.0",


### PR DESCRIPTION
Extra packages that most users don't use and currently we don't have resources to maintain it (not working with ng8).