### PR TITLE
chore: update zone.js to latest

### DIFF
--- a/packages/template-blank-ng/package.json
+++ b/packages/template-blank-ng/package.json
@@ -49,7 +49,7 @@
     "reflect-metadata": "~0.1.12",
     "rxjs": "~6.5.0",
     "tns-core-modules": "~5.4.0",
-    "zone.js": "~0.8.26"
+    "zone.js": "~0.9.1"
   },
   "devDependencies": {
     "@angular/compiler-cli": "~8.0.0",

--- a/packages/template-drawer-navigation-ng/package.json
+++ b/packages/template-drawer-navigation-ng/package.json
@@ -56,7 +56,7 @@
     "reflect-metadata": "~0.1.12",
     "rxjs": "~6.5.0",
     "tns-core-modules": "~5.4.0",
-    "zone.js": "~0.8.26"
+    "zone.js": "~0.9.1"
   },
   "devDependencies": {
     "@angular/compiler-cli": "~8.0.0",

--- a/packages/template-enterprise-auth-ng/package.json
+++ b/packages/template-enterprise-auth-ng/package.json
@@ -56,7 +56,7 @@
     "reflect-metadata": "~0.1.10",
     "rxjs": "~6.5.0",
     "tns-core-modules": "~5.4.0",
-    "zone.js": "~0.8.18"
+    "zone.js": "~0.9.1"
   },
   "devDependencies": {
     "@angular/compiler-cli": "~8.0.0",

--- a/packages/template-health-survey-ng/package.json
+++ b/packages/template-health-survey-ng/package.json
@@ -56,7 +56,7 @@
     "reflect-metadata": "~0.1.12",
     "rxjs": "~6.5.0",
     "tns-core-modules": "~5.4.0",
-    "zone.js": "~0.8.26"
+    "zone.js": "~0.9.1"
   },
   "devDependencies": {
     "@angular/compiler-cli": "~8.0.0",

--- a/packages/template-hello-world-ng/package.json
+++ b/packages/template-hello-world-ng/package.json
@@ -47,7 +47,7 @@
     "reflect-metadata": "~0.1.12",
     "rxjs": "~6.5.0",
     "tns-core-modules": "~5.4.0",
-    "zone.js": "~0.8.26"
+    "zone.js": "~0.9.1"
   },
   "devDependencies": {
     "@angular/compiler-cli": "~8.0.0",

--- a/packages/template-master-detail-kinvey-ng/package.json
+++ b/packages/template-master-detail-kinvey-ng/package.json
@@ -56,7 +56,7 @@
     "reflect-metadata": "~0.1.12",
     "rxjs": "~6.5.0",
     "tns-core-modules": "~5.4.0",
-    "zone.js": "~0.8.26"
+    "zone.js": "~0.9.1"
   },
   "devDependencies": {
     "@angular/compiler-cli": "~8.0.0",

--- a/packages/template-master-detail-ng/package.json
+++ b/packages/template-master-detail-ng/package.json
@@ -57,7 +57,7 @@
     "reflect-metadata": "~0.1.12",
     "rxjs": "~6.5.0",
     "tns-core-modules": "~5.4.0",
-    "zone.js": "~0.8.26"
+    "zone.js": "~0.9.1"
   },
   "devDependencies": {
     "@angular/compiler-cli": "~8.0.0",

--- a/packages/template-patient-care-ng/package.json
+++ b/packages/template-patient-care-ng/package.json
@@ -59,7 +59,7 @@
     "reflect-metadata": "~0.1.12",
     "rxjs": "~6.5.0",
     "tns-core-modules": "~5.4.0",
-    "zone.js": "~0.8.26"
+    "zone.js": "~0.9.1"
   },
   "devDependencies": {
     "@angular/compiler-cli": "~8.0.0",

--- a/packages/template-tab-navigation-ng/package.json
+++ b/packages/template-tab-navigation-ng/package.json
@@ -55,7 +55,7 @@
     "reflect-metadata": "~0.1.12",
     "rxjs": "~6.5.0",
     "tns-core-modules": "~5.4.0",
-    "zone.js": "~0.8.26"
+    "zone.js": "~0.9.1"
   },
   "devDependencies": {
     "@angular/compiler-cli": "~8.0.0",


### PR DESCRIPTION
Getting the following warning:
```
npm WARN @angular/core@8.0.0 requires a peer of zone.js@~0.9.1 but none is installed. You must install peer dependencies yourself.
```

So updated zone.js to latest.