### PR TITLE
refactor(ng): remove `moduleId: module.id` from components

### DIFF
--- a/packages/template-blank-ng/src/app/app.component.ts
+++ b/packages/template-blank-ng/src/app/app.component.ts
@@ -1,7 +1,6 @@
 import { Component } from "@angular/core";
 
 @Component({
-    moduleId: module.id,
     selector: "ns-app",
     templateUrl: "app.component.html"
 })

--- a/packages/template-blank-ng/src/app/home/home.component.ts
+++ b/packages/template-blank-ng/src/app/home/home.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit } from "@angular/core";
 
 @Component({
     selector: "Home",
-    moduleId: module.id,
     templateUrl: "./home.component.html"
 })
 export class HomeComponent implements OnInit {

--- a/packages/template-drawer-navigation-ng/src/app/app.component.ts
+++ b/packages/template-drawer-navigation-ng/src/app/app.component.ts
@@ -6,7 +6,6 @@ import { filter } from "rxjs/operators";
 import * as app from "tns-core-modules/application";
 
 @Component({
-    moduleId: module.id,
     selector: "ns-app",
     templateUrl: "app.component.html"
 })

--- a/packages/template-drawer-navigation-ng/src/app/browse/browse.component.ts
+++ b/packages/template-drawer-navigation-ng/src/app/browse/browse.component.ts
@@ -4,7 +4,6 @@ import * as app from "tns-core-modules/application";
 
 @Component({
     selector: "Browse",
-    moduleId: module.id,
     templateUrl: "./browse.component.html"
 })
 export class BrowseComponent implements OnInit {

--- a/packages/template-drawer-navigation-ng/src/app/featured/featured.component.ts
+++ b/packages/template-drawer-navigation-ng/src/app/featured/featured.component.ts
@@ -4,7 +4,6 @@ import * as app from "tns-core-modules/application";
 
 @Component({
     selector: "Featured",
-    moduleId: module.id,
     templateUrl: "./featured.component.html"
 })
 export class FeaturedComponent implements OnInit {

--- a/packages/template-drawer-navigation-ng/src/app/home/home.component.ts
+++ b/packages/template-drawer-navigation-ng/src/app/home/home.component.ts
@@ -4,7 +4,6 @@ import * as app from "tns-core-modules/application";
 
 @Component({
     selector: "Home",
-    moduleId: module.id,
     templateUrl: "./home.component.html"
 })
 export class HomeComponent implements OnInit {

--- a/packages/template-drawer-navigation-ng/src/app/search/search.component.ts
+++ b/packages/template-drawer-navigation-ng/src/app/search/search.component.ts
@@ -4,7 +4,6 @@ import * as app from "tns-core-modules/application";
 
 @Component({
     selector: "Search",
-    moduleId: module.id,
     templateUrl: "./search.component.html"
 })
 export class SearchComponent implements OnInit {

--- a/packages/template-drawer-navigation-ng/src/app/settings/settings.component.ts
+++ b/packages/template-drawer-navigation-ng/src/app/settings/settings.component.ts
@@ -4,7 +4,6 @@ import * as app from "tns-core-modules/application";
 
 @Component({
     selector: "Settings",
-    moduleId: module.id,
     templateUrl: "./settings.component.html"
 })
 export class SettingsComponent implements OnInit {

--- a/packages/template-enterprise-auth-ng/src/app/app.component.ts
+++ b/packages/template-enterprise-auth-ng/src/app/app.component.ts
@@ -1,7 +1,6 @@
 import { Component } from "@angular/core";
 
 @Component({
-    moduleId: module.id,
     selector: "ns-app",
     templateUrl: "app.component.html"
 })

--- a/packages/template-enterprise-auth-ng/src/app/home/home.component.ts
+++ b/packages/template-enterprise-auth-ng/src/app/home/home.component.ts
@@ -9,7 +9,6 @@ import { StackLayout } from "tns-core-modules/ui/layouts/stack-layout";
 
 @Component({
     selector: "Home",
-    moduleId: module.id,
     templateUrl: "./home.component.html"
 })
 export class HomeComponent implements OnInit {

--- a/packages/template-enterprise-auth-ng/src/app/login/login.component.ts
+++ b/packages/template-enterprise-auth-ng/src/app/login/login.component.ts
@@ -7,7 +7,6 @@ import { Page } from "tns-core-modules/ui/page";
 
 @Component({
     selector: "Login",
-    moduleId: module.id,
     templateUrl: "./login.component.html"
 })
 export class LoginComponent {

--- a/packages/template-health-survey-ng/src/app/app.component.ts
+++ b/packages/template-health-survey-ng/src/app/app.component.ts
@@ -1,7 +1,6 @@
 import { Component } from "@angular/core";
 
 @Component({
-    moduleId: module.id,
     selector: "ns-app",
     templateUrl: "app.component.html"
 })

--- a/packages/template-health-survey-ng/src/app/consent/consent-review/consent/consent.component.ts
+++ b/packages/template-health-survey-ng/src/app/consent/consent-review/consent/consent.component.ts
@@ -11,7 +11,6 @@ import { ConsentForm } from "./consent-form.model";
 
 @Component({
     selector: "Consent",
-    moduleId: module.id,
     templateUrl: "./consent.component.html",
     styleUrls: ["../../consent-common.css"]
 })

--- a/packages/template-health-survey-ng/src/app/consent/consent-review/review/review.component.ts
+++ b/packages/template-health-survey-ng/src/app/consent/consent-review/review/review.component.ts
@@ -5,7 +5,6 @@ import { AppService } from "../../../shared/app.service";
 
 @Component({
     selector: "Review",
-    moduleId: module.id,
     templateUrl: "./review.component.html",
     styleUrls: ["../../consent-common.css"]
 })

--- a/packages/template-health-survey-ng/src/app/consent/consent-sharing/consent-sharing.component.ts
+++ b/packages/template-health-survey-ng/src/app/consent/consent-sharing/consent-sharing.component.ts
@@ -7,7 +7,6 @@ import { AppService } from "../../shared/app.service";
 
 @Component({
     selector: "ConsentSharing",
-    moduleId: module.id,
     templateUrl: "./consent-sharing.component.html",
     styleUrls: ["../consent-common.css"]
 })

--- a/packages/template-health-survey-ng/src/app/consent/visual-consent/data-gathering/data-gathering.component.ts
+++ b/packages/template-health-survey-ng/src/app/consent/visual-consent/data-gathering/data-gathering.component.ts
@@ -5,7 +5,6 @@ import { AppService } from "../../../shared/app.service";
 
 @Component({
     selector: "DataGathering",
-    moduleId: module.id,
     templateUrl: "./data-gathering.component.html",
     styleUrls: ["../../consent-common.css"]
 })

--- a/packages/template-health-survey-ng/src/app/consent/visual-consent/data-use/data-use.component.ts
+++ b/packages/template-health-survey-ng/src/app/consent/visual-consent/data-use/data-use.component.ts
@@ -5,7 +5,6 @@ import { AppService } from "../../../shared/app.service";
 
 @Component({
     selector: "DataUse",
-    moduleId: module.id,
     templateUrl: "./data-use.component.html",
     styleUrls: ["../../consent-common.css"]
 })

--- a/packages/template-health-survey-ng/src/app/consent/visual-consent/study-survey/study-survey.component.ts
+++ b/packages/template-health-survey-ng/src/app/consent/visual-consent/study-survey/study-survey.component.ts
@@ -5,7 +5,6 @@ import { AppService } from "../../../shared/app.service";
 
 @Component({
     selector: "StudySurvey",
-    moduleId: module.id,
     templateUrl: "./study-survey.component.html",
     styleUrls: ["../../consent-common.css"]
 })

--- a/packages/template-health-survey-ng/src/app/consent/visual-consent/time-commitment/time-commitment.component.ts
+++ b/packages/template-health-survey-ng/src/app/consent/visual-consent/time-commitment/time-commitment.component.ts
@@ -5,7 +5,6 @@ import { AppService } from "../../../shared/app.service";
 
 @Component({
     selector: "TimeCommitment",
-    moduleId: module.id,
     templateUrl: "./time-commitment.component.html",
     styleUrls: ["../../consent-common.css"]
 })

--- a/packages/template-health-survey-ng/src/app/consent/visual-consent/withdrawing/withdrawing.component.ts
+++ b/packages/template-health-survey-ng/src/app/consent/visual-consent/withdrawing/withdrawing.component.ts
@@ -7,7 +7,6 @@ import { AppService } from "../../../shared/app.service";
 
 @Component({
     selector: "Withdrawing",
-    moduleId: module.id,
     templateUrl: "./withdrawing.component.html",
     styleUrls: ["../../consent-common.css"]
 })

--- a/packages/template-health-survey-ng/src/app/consent/welcome.component.ts
+++ b/packages/template-health-survey-ng/src/app/consent/welcome.component.ts
@@ -5,7 +5,6 @@ import { AppService } from "../shared/app.service";
 
 @Component({
     selector: "Welcome",
-    moduleId: module.id,
     templateUrl: "./welcome.component.html",
     styleUrls: ["./consent-common.css"]
 })

--- a/packages/template-health-survey-ng/src/app/login/login.component.ts
+++ b/packages/template-health-survey-ng/src/app/login/login.component.ts
@@ -13,7 +13,6 @@ import { LoginForm } from "./login-form.model";
 
 @Component({
     selector: "Login",
-    moduleId: module.id,
     templateUrl: "./login.component.html"
 })
 export class LoginComponent implements OnInit {

--- a/packages/template-health-survey-ng/src/app/login/registration/registration.component.ts
+++ b/packages/template-health-survey-ng/src/app/login/registration/registration.component.ts
@@ -15,7 +15,6 @@ import { RegistrationForm } from "./registration-form.model";
 
 @Component({
     selector: "Registration",
-    moduleId: module.id,
     templateUrl: "./registration.component.html"
 })
 export class RegistrationComponent implements OnInit {

--- a/packages/template-health-survey-ng/src/app/survey/survey-boolean-question.component.ts
+++ b/packages/template-health-survey-ng/src/app/survey/survey-boolean-question.component.ts
@@ -7,7 +7,6 @@ import { AppService } from "../shared/app.service";
 
 @Component({
     selector: "SurveyBooleanQuestion",
-    moduleId: module.id,
     templateUrl: "./survey-boolean-question.component.html"
 })
 export class SurveyBooleanQuestionComponent implements OnInit {

--- a/packages/template-health-survey-ng/src/app/survey/survey-complete/survey-complete.component.ts
+++ b/packages/template-health-survey-ng/src/app/survey/survey-complete/survey-complete.component.ts
@@ -5,7 +5,6 @@ import { AppService } from "../../shared/app.service";
 
 @Component({
     selector: "Complete",
-    moduleId: module.id,
     templateUrl: "./survey-complete.component.html"
 })
 export class SurveyCompleteComponent implements OnInit {

--- a/packages/template-health-survey-ng/src/app/survey/survey-date-question.component.ts
+++ b/packages/template-health-survey-ng/src/app/survey/survey-date-question.component.ts
@@ -7,7 +7,6 @@ import { AppService } from "../shared/app.service";
 
 @Component({
     selector: "SurveyDateQuestion",
-    moduleId: module.id,
     templateUrl: "./survey-date-question.component.html"
 })
 export class SurveyDateQuestionComponent implements OnInit {

--- a/packages/template-health-survey-ng/src/app/survey/survey-text-question.component.ts
+++ b/packages/template-health-survey-ng/src/app/survey/survey-text-question.component.ts
@@ -7,7 +7,6 @@ import { AppService } from "../shared/app.service";
 
 @Component({
     selector: "SurveyTextQuestion",
-    moduleId: module.id,
     templateUrl: "./survey-text-question.component.html"
 })
 export class SurveyTextQuestionComponent {

--- a/packages/template-hello-world-ng/src/app/app.component.ts
+++ b/packages/template-hello-world-ng/src/app/app.component.ts
@@ -2,7 +2,6 @@ import { Component } from "@angular/core";
 
 @Component({
     selector: "ns-app",
-    moduleId: module.id,
     templateUrl: "./app.component.html"
 })
 export class AppComponent { }

--- a/packages/template-hello-world-ng/src/app/item/item-detail.component.ts
+++ b/packages/template-hello-world-ng/src/app/item/item-detail.component.ts
@@ -6,7 +6,6 @@ import { ItemService } from "./item.service";
 
 @Component({
     selector: "ns-details",
-    moduleId: module.id,
     templateUrl: "./item-detail.component.html"
 })
 export class ItemDetailComponent implements OnInit {

--- a/packages/template-hello-world-ng/src/app/item/items.component.ts
+++ b/packages/template-hello-world-ng/src/app/item/items.component.ts
@@ -5,7 +5,6 @@ import { ItemService } from "./item.service";
 
 @Component({
     selector: "ns-items",
-    moduleId: module.id,
     templateUrl: "./items.component.html"
 })
 export class ItemsComponent implements OnInit {

--- a/packages/template-master-detail-kinvey-ng/src/app/app.component.ts
+++ b/packages/template-master-detail-kinvey-ng/src/app/app.component.ts
@@ -1,7 +1,6 @@
 import { Component } from "@angular/core";
 
 @Component({
-    moduleId: module.id,
     selector: "ns-app",
     templateUrl: "app.component.html"
 })

--- a/packages/template-master-detail-kinvey-ng/src/app/cars/car-detail-edit/car-detail-edit.component.ts
+++ b/packages/template-master-detail-kinvey-ng/src/app/cars/car-detail-edit/car-detail-edit.component.ts
@@ -13,7 +13,6 @@ import { carClassList, carDoorList, carSeatList, carTransmissionList } from "./c
 * This component gets the selected data item, provides options to edit the item and saves the changes.
 *************************************************************/
 @Component({
-    moduleId: module.id,
     selector: "CarDetailEdit",
     templateUrl: "./car-detail-edit.component.html",
     styleUrls: ["./car-detail-edit.component.scss"]

--- a/packages/template-master-detail-kinvey-ng/src/app/cars/car-detail-edit/my-image-add-remove/my-image-add-remove.component.ts
+++ b/packages/template-master-detail-kinvey-ng/src/app/cars/car-detail-edit/my-image-add-remove/my-image-add-remove.component.ts
@@ -20,7 +20,6 @@ const MY_IMAGE_ADD_REMOVE_CONTROL_VALUE_ACCESSOR = {
 *************************************************************/
 @Component({
     selector: "MyImageAddRemove",
-    moduleId: module.id,
     templateUrl: "./my-image-add-remove.component.html",
     styleUrls: ["./my-image-add-remove.component.scss"],
     providers: [MY_IMAGE_ADD_REMOVE_CONTROL_VALUE_ACCESSOR]

--- a/packages/template-master-detail-kinvey-ng/src/app/cars/car-detail-edit/my-list-selector/my-list-selector-modal-view.component.ts
+++ b/packages/template-master-detail-kinvey-ng/src/app/cars/car-detail-edit/my-list-selector/my-list-selector-modal-view.component.ts
@@ -3,7 +3,6 @@ import { ModalDialogParams } from "nativescript-angular/modal-dialog";
 
 @Component({
     selector: "MyListSelectorModalView",
-    moduleId: module.id,
     templateUrl: "./my-list-selector-modal-view.component.html",
     styleUrls: ["./my-list-selector-modal-view.component.scss"]
 })

--- a/packages/template-master-detail-kinvey-ng/src/app/cars/car-detail-edit/my-list-selector/my-list-selector.component.ts
+++ b/packages/template-master-detail-kinvey-ng/src/app/cars/car-detail-edit/my-list-selector/my-list-selector.component.ts
@@ -16,7 +16,6 @@ const capitalizeFirstLetter = (s) => s.charAt(0).toUpperCase() + s.slice(1);
 * https://docs.nativescript.org/angular/code-samples/modal-page
 *************************************************************/
 @Component({
-    moduleId: module.id,
     providers: [ModalDialogService],
     selector: "MyListSelector",
     templateUrl: "./my-list-selector.component.html"

--- a/packages/template-master-detail-kinvey-ng/src/app/cars/car-detail/car-detail.component.ts
+++ b/packages/template-master-detail-kinvey-ng/src/app/cars/car-detail/car-detail.component.ts
@@ -12,7 +12,6 @@ import { CarService } from "../shared/car.service";
 *************************************************************/
 @Component({
     selector: "CarDetail",
-    moduleId: module.id,
     templateUrl: "./car-detail.component.html"
 })
 export class CarDetailComponent implements OnInit {

--- a/packages/template-master-detail-kinvey-ng/src/app/cars/car-list.component.ts
+++ b/packages/template-master-detail-kinvey-ng/src/app/cars/car-list.component.ts
@@ -13,7 +13,6 @@ import { CarService } from "./shared/car.service";
 *************************************************************/
 @Component({
     selector: "CarsList",
-    moduleId: module.id,
     templateUrl: "./car-list.component.html",
     styleUrls: ["./car-list.component.scss"]
 })

--- a/packages/template-master-detail-ng/src/app/app.component.ts
+++ b/packages/template-master-detail-ng/src/app/app.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit } from "@angular/core";
 import { initFirebase } from "./shared/firebase.common";
 
 @Component({
-    moduleId: module.id,
     selector: "ns-app",
     templateUrl: "app.component.html"
 })

--- a/packages/template-master-detail-ng/src/app/cars/car-detail-edit/car-detail-edit.component.ts
+++ b/packages/template-master-detail-ng/src/app/cars/car-detail-edit/car-detail-edit.component.ts
@@ -9,7 +9,6 @@ import { CarService } from "../shared/car.service";
 import { carClassList, carDoorList, carSeatList, carTransmissionList } from "./constants";
 
 @Component({
-    moduleId: module.id,
     selector: "CarDetailEdit",
     templateUrl: "./car-detail-edit.component.html",
     styleUrls: ["./car-detail-edit.component.scss"]

--- a/packages/template-master-detail-ng/src/app/cars/car-detail-edit/my-image-add-remove/my-image-add-remove.component.ts
+++ b/packages/template-master-detail-ng/src/app/cars/car-detail-edit/my-image-add-remove/my-image-add-remove.component.ts
@@ -20,7 +20,6 @@ const MY_IMAGE_ADD_REMOVE_CONTROL_VALUE_ACCESSOR = {
 *************************************************************/
 @Component({
     selector: "MyImageAddRemove",
-    moduleId: module.id,
     templateUrl: "./my-image-add-remove.component.html",
     styleUrls: ["./my-image-add-remove.component.scss"],
     providers: [MY_IMAGE_ADD_REMOVE_CONTROL_VALUE_ACCESSOR]

--- a/packages/template-master-detail-ng/src/app/cars/car-detail-edit/my-list-selector/my-list-selector-modal-view.component.ts
+++ b/packages/template-master-detail-ng/src/app/cars/car-detail-edit/my-list-selector/my-list-selector-modal-view.component.ts
@@ -3,7 +3,6 @@ import { ModalDialogParams } from "nativescript-angular/modal-dialog";
 
 @Component({
     selector: "MyListSelectorModalView",
-    moduleId: module.id,
     templateUrl: "./my-list-selector-modal-view.component.html",
     styleUrls: ["./my-list-selector-modal-view.component.scss"]
 })

--- a/packages/template-master-detail-ng/src/app/cars/car-detail-edit/my-list-selector/my-list-selector.component.ts
+++ b/packages/template-master-detail-ng/src/app/cars/car-detail-edit/my-list-selector/my-list-selector.component.ts
@@ -16,7 +16,6 @@ const capitalizeFirstLetter = (s) => s.charAt(0).toUpperCase() + s.slice(1);
 * https://docs.nativescript.org/angular/code-samples/modal-page
 *************************************************************/
 @Component({
-    moduleId: module.id,
     providers: [ModalDialogService],
     selector: "MyListSelector",
     templateUrl: "./my-list-selector.component.html"

--- a/packages/template-master-detail-ng/src/app/cars/car-detail/car-detail.component.ts
+++ b/packages/template-master-detail-ng/src/app/cars/car-detail/car-detail.component.ts
@@ -12,7 +12,6 @@ import { CarService } from "../shared/car.service";
 *************************************************************/
 @Component({
     selector: "CarDetail",
-    moduleId: module.id,
     templateUrl: "./car-detail.component.html"
 })
 export class CarDetailComponent implements OnInit {

--- a/packages/template-master-detail-ng/src/app/cars/car-list.component.ts
+++ b/packages/template-master-detail-ng/src/app/cars/car-list.component.ts
@@ -10,7 +10,6 @@ import { CarService } from "./shared/car.service";
 
 @Component({
     selector: "CarsList",
-    moduleId: module.id,
     templateUrl: "./car-list.component.html",
     styleUrls: ["./car-list.component.scss"]
 })

--- a/packages/template-patient-care-ng/src/care/care-card/activity-detail/activity-detail.component.ts
+++ b/packages/template-patient-care-ng/src/care/care-card/activity-detail/activity-detail.component.ts
@@ -14,7 +14,6 @@ const IOS_KEYBOARDTYPE_DECIMALPAD: number = 8;
 
 @Component({
     selector: "ActivityDetails",
-    moduleId: module.id,
     templateUrl: "./activity-detail.component.html",
     styleUrls: ["./activity-detail.component.css", "../../care-common.css"]
 })

--- a/packages/template-patient-care-ng/src/care/care-card/activity/activity-list.component.ts
+++ b/packages/template-patient-care-ng/src/care/care-card/activity/activity-list.component.ts
@@ -10,7 +10,6 @@ import { CarePlanEvent } from "../shared/care-plan-event.model";
 
 @Component({
     selector: "ActivityList",
-    moduleId: module.id,
     templateUrl: "./activity-list.component.html",
     styleUrls: ["../../care-common.css"]
 })

--- a/packages/template-patient-care-ng/src/care/care-card/care-card.component.ts
+++ b/packages/template-patient-care-ng/src/care/care-card/care-card.component.ts
@@ -2,7 +2,6 @@ import { Component } from "@angular/core";
 
 @Component({
     selector: "CareCard",
-    moduleId: module.id,
     templateUrl: "./care-card.component.html",
     styleUrls: ["../care-common.css"]
 })

--- a/packages/template-patient-care-ng/src/care/care-card/care-dashboard/care-dashboard.component.ts
+++ b/packages/template-patient-care-ng/src/care/care-card/care-dashboard/care-dashboard.component.ts
@@ -7,7 +7,6 @@ import { CarePlanEvent } from "../shared/care-plan-event.model";
 
 @Component({
     selector: "CareDashboard",
-    moduleId: module.id,
     templateUrl: "./care-dashboard.component.html",
     styleUrls: ["./care-dashboard.component.css", "../../care-common.css"]
 })

--- a/packages/template-patient-care-ng/src/care/care-card/care-dashboard/radial-rating/radial-rating.component.ts
+++ b/packages/template-patient-care-ng/src/care/care-card/care-dashboard/radial-rating/radial-rating.component.ts
@@ -7,7 +7,6 @@ const radialAnimationDurationMilliseconds = 1000;
 
 @Component({
     selector: "RadialRating",
-    moduleId: module.id,
     templateUrl: "./radial-rating.component.html",
     styleUrls: ["./radial-rating.component.css"]
 })

--- a/packages/template-patient-care-ng/src/care/care.component.ts
+++ b/packages/template-patient-care-ng/src/care/care.component.ts
@@ -4,7 +4,6 @@ import { SelectedIndexChangedEventData, TabView } from "tns-core-modules/ui/tab-
 
 @Component({
     selector: "CareComponent",
-    moduleId: module.id,
     templateUrl: "./care.component.html",
     styleUrls: ["./care-common.css"]
 })

--- a/packages/template-patient-care-ng/src/care/connect/connect-detail/connect-detail.component.ts
+++ b/packages/template-patient-care-ng/src/care/connect/connect-detail/connect-detail.component.ts
@@ -10,7 +10,6 @@ import { Contact } from "../shared/contact.model";
 
 @Component({
     selector: "ConnectDetail",
-    moduleId: module.id,
     templateUrl: "./connect-detail.component.html",
     styleUrls: ["../connect.component.css", "../../care-common.css"]
 })

--- a/packages/template-patient-care-ng/src/care/connect/connect.component.ts
+++ b/packages/template-patient-care-ng/src/care/connect/connect.component.ts
@@ -8,7 +8,6 @@ import { Contact } from "./shared/contact.model";
 
 @Component({
     selector: "Connect",
-    moduleId: module.id,
     templateUrl: "./connect.component.html",
     styleUrls: ["./connect.component.css", "../care-common.css"]
 })

--- a/packages/template-patient-care-ng/src/login/login.component.ts
+++ b/packages/template-patient-care-ng/src/login/login.component.ts
@@ -13,7 +13,6 @@ import { LoginForm } from "./login-form.model";
 
 @Component({
     selector: "Login",
-    moduleId: module.id,
     templateUrl: "./login.component.html"
 })
 export class LoginComponent implements OnInit {

--- a/packages/template-patient-care-ng/src/login/registration/registration.component.ts
+++ b/packages/template-patient-care-ng/src/login/registration/registration.component.ts
@@ -13,7 +13,6 @@ import { RegistrationForm } from "./registration-form.model";
 
 @Component({
     selector: "Registration",
-    moduleId: module.id,
     templateUrl: "./registration.component.html"
 })
 export class RegistrationComponent implements OnInit {

--- a/packages/template-tab-navigation-ng/src/app/app.component.ts
+++ b/packages/template-tab-navigation-ng/src/app/app.component.ts
@@ -3,7 +3,6 @@ import { isAndroid } from "tns-core-modules/platform";
 
 @Component({
     selector: "ns-app",
-    moduleId: module.id,
     templateUrl: "app.component.html",
     styleUrls: ["./app.component.scss"]
 })

--- a/packages/template-tab-navigation-ng/src/app/browse/browse.component.ts
+++ b/packages/template-tab-navigation-ng/src/app/browse/browse.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit } from "@angular/core";
 
 @Component({
     selector: "Browse",
-    moduleId: module.id,
     templateUrl: "./browse.component.html"
 })
 export class BrowseComponent implements OnInit {

--- a/packages/template-tab-navigation-ng/src/app/home/home.component.ts
+++ b/packages/template-tab-navigation-ng/src/app/home/home.component.ts
@@ -3,7 +3,6 @@ import { DataService, IDataItem } from "../shared/data.service";
 
 @Component({
     selector: "Home",
-    moduleId: module.id,
     templateUrl: "./home.component.html"
 })
 export class HomeComponent implements OnInit {

--- a/packages/template-tab-navigation-ng/src/app/home/item-detail/item-detail.component.ts
+++ b/packages/template-tab-navigation-ng/src/app/home/item-detail/item-detail.component.ts
@@ -5,7 +5,6 @@ import { DataService, IDataItem } from "../../shared/data.service";
 
 @Component({
     selector: "ItemDetail",
-    moduleId: module.id,
     templateUrl: "./item-detail.component.html"
 })
 export class ItemDetailComponent implements OnInit {

--- a/packages/template-tab-navigation-ng/src/app/search/search.component.ts
+++ b/packages/template-tab-navigation-ng/src/app/search/search.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit } from "@angular/core";
 
 @Component({
     selector: "Search",
-    moduleId: module.id,
     templateUrl: "./search.component.html"
 })
 export class SearchComponent implements OnInit {


### PR DESCRIPTION
{N} 6.0 uses only webpack for building. When building Angular apps with
Webpack,the `module.id` is inserted automatically and we don't need to
set it manually. There's even a loader in `nativescript-dev-webpack` which removes the `moduleId`s from the source code.

In short, the `moduleId: module.id` is useful only for builds without webpack. NativeScript 6.0 doesn't support such builds. That's why we don't need `moduleId` in the templates anymore.