### PR TITLE
feat: add skipLibCheck: true for all TypeScript enabled templates

### DIFF
--- a/packages/template-blank-ng/tsconfig.json
+++ b/packages/template-blank-ng/tsconfig.json
@@ -6,6 +6,7 @@
         "emitDecoratorMetadata": true,
         "noEmitHelpers": true,
         "noEmitOnError": true,
+        "skipLibCheck": true,
         "lib": [
             "es6",
             "dom",

--- a/packages/template-blank-ts/tsconfig.json
+++ b/packages/template-blank-ts/tsconfig.json
@@ -6,6 +6,7 @@
         "emitDecoratorMetadata": true,
         "noEmitHelpers": true,
         "noEmitOnError": true,
+        "skipLibCheck": true,
         "lib": [
             "es6",
             "dom"

--- a/packages/template-drawer-navigation-ng/tsconfig.json
+++ b/packages/template-drawer-navigation-ng/tsconfig.json
@@ -6,6 +6,7 @@
         "emitDecoratorMetadata": true,
         "noEmitHelpers": true,
         "noEmitOnError": true,
+        "skipLibCheck": true,
         "lib": [
             "es6",
             "dom",

--- a/packages/template-drawer-navigation-ts/tsconfig.json
+++ b/packages/template-drawer-navigation-ts/tsconfig.json
@@ -6,6 +6,7 @@
         "emitDecoratorMetadata": true,
         "noEmitHelpers": true,
         "noEmitOnError": true,
+        "skipLibCheck": true,
         "lib": [
             "es6",
             "dom"

--- a/packages/template-enterprise-auth-ng/tsconfig.json
+++ b/packages/template-enterprise-auth-ng/tsconfig.json
@@ -6,6 +6,7 @@
         "emitDecoratorMetadata": true,
         "noEmitHelpers": true,
         "noEmitOnError": true,
+        "skipLibCheck": true,
         "lib": [
             "es6",
             "dom",

--- a/packages/template-enterprise-auth-ts/tsconfig.json
+++ b/packages/template-enterprise-auth-ts/tsconfig.json
@@ -6,6 +6,7 @@
         "emitDecoratorMetadata": true,
         "noEmitHelpers": true,
         "noEmitOnError": true,
+        "skipLibCheck": true,
         "lib": [
             "es6",
             "dom"

--- a/packages/template-health-survey-ng/tsconfig.json
+++ b/packages/template-health-survey-ng/tsconfig.json
@@ -6,6 +6,7 @@
         "emitDecoratorMetadata": true,
         "noEmitHelpers": true,
         "noEmitOnError": true,
+        "skipLibCheck": true,
         "lib": [
             "es6",
             "dom",

--- a/packages/template-hello-world-ng/tsconfig.json
+++ b/packages/template-hello-world-ng/tsconfig.json
@@ -6,6 +6,7 @@
         "emitDecoratorMetadata": true,
         "noEmitHelpers": true,
         "noEmitOnError": true,
+        "skipLibCheck": true,
         "lib": [
             "es6",
             "dom",

--- a/packages/template-hello-world-ts/tsconfig.json
+++ b/packages/template-hello-world-ts/tsconfig.json
@@ -6,6 +6,7 @@
         "emitDecoratorMetadata": true,
         "noEmitHelpers": true,
         "noEmitOnError": true,
+        "skipLibCheck": true,
         "lib": [
             "es6",
             "dom"

--- a/packages/template-master-detail-kinvey-ng/tsconfig.json
+++ b/packages/template-master-detail-kinvey-ng/tsconfig.json
@@ -6,6 +6,7 @@
         "emitDecoratorMetadata": true,
         "noEmitHelpers": true,
         "noEmitOnError": true,
+        "skipLibCheck": true,
         "lib": [
             "es6",
             "dom",

--- a/packages/template-master-detail-kinvey-ts/tsconfig.json
+++ b/packages/template-master-detail-kinvey-ts/tsconfig.json
@@ -6,6 +6,7 @@
         "emitDecoratorMetadata": true,
         "noEmitHelpers": true,
         "noEmitOnError": true,
+        "skipLibCheck": true,
         "lib": [
             "es6",
             "dom"

--- a/packages/template-master-detail-ng/tsconfig.json
+++ b/packages/template-master-detail-ng/tsconfig.json
@@ -6,6 +6,7 @@
         "emitDecoratorMetadata": true,
         "noEmitHelpers": true,
         "noEmitOnError": true,
+        "skipLibCheck": true,
         "lib": [
             "es6",
             "dom",

--- a/packages/template-master-detail-ts/tsconfig.json
+++ b/packages/template-master-detail-ts/tsconfig.json
@@ -6,6 +6,7 @@
         "emitDecoratorMetadata": true,
         "noEmitHelpers": true,
         "noEmitOnError": true,
+        "skipLibCheck": true,
         "lib": [
             "es6",
             "dom"

--- a/packages/template-patient-care-ng/tsconfig.json
+++ b/packages/template-patient-care-ng/tsconfig.json
@@ -6,6 +6,7 @@
         "emitDecoratorMetadata": true,
         "noEmitHelpers": true,
         "noEmitOnError": true,
+        "skipLibCheck": true,
         "lib": [
             "es6",
             "dom",

--- a/packages/template-tab-navigation-ng/tsconfig.json
+++ b/packages/template-tab-navigation-ng/tsconfig.json
@@ -6,6 +6,7 @@
         "emitDecoratorMetadata": true,
         "noEmitHelpers": true,
         "noEmitOnError": true,
+        "skipLibCheck": true,
         "lib": [
             "es6",
             "dom",

--- a/packages/template-tab-navigation-ts/tsconfig.json
+++ b/packages/template-tab-navigation-ts/tsconfig.json
@@ -6,6 +6,7 @@
         "emitDecoratorMetadata": true,
         "noEmitHelpers": true,
         "noEmitOnError": true,
+        "skipLibCheck": true,
         "lib": [
             "es6",
             "dom"


### PR DESCRIPTION
Using `skipLibCheck` to skip type checking of all declaration files (*.d.ts) in `node_modules`. Applied to all  TypeScript and Angular templates.

Closes: https://github.com/NativeScript/NativeScript/issues/7552



