### PR TITLE
chore(kinvey): force tslib@^1.9.3

### DIFF
--- a/packages/template-master-detail-kinvey-ts/package.json
+++ b/packages/template-master-detail-kinvey-ts/package.json
@@ -44,7 +44,8 @@
     "nativescript-imagepicker": "~6.2.0",
     "nativescript-theme-core": "~1.0.6",
     "nativescript-ui-listview": "~7.0.0",
-    "tns-core-modules": "~6.0.0"
+    "tns-core-modules": "~6.0.0",
+    "tslib": "^1.9.3"
   },
   "devDependencies": {
     "nativescript-dev-webpack": "~1.1.0",

--- a/packages/template-master-detail-kinvey/package.json
+++ b/packages/template-master-detail-kinvey/package.json
@@ -45,7 +45,8 @@
     "nativescript-imagepicker": "~6.2.0",
     "nativescript-theme-core": "~1.0.6",
     "nativescript-ui-listview": "~7.0.0",
-    "tns-core-modules": "~6.0.0"
+    "tns-core-modules": "~6.0.0",
+    "tslib": "^1.9.3"
   },
   "devDependencies": {
     "eslint": "~5.8.0",


### PR DESCRIPTION
Force JS & TS Kinvey templates to use tslib@^1.9.3 (i.e. the version referenced by tns-core-modules 1.10.0) -- currently it seems there is a breaking change between tslib@1.9.3 and tslib@1.10.0 which causes the tns-core-modules code (transpiled agains 1.10.0) to use a new spread operator syntax that does not work with 1.9.3. On the other hand kinvey-nativescript-sdk@4.2.3 uses tslib@1.9.3 as a hardcoded version and this somehow forces the whole app to use 1.9.3.