### PR TITLE
fix(webpack): tsconfig.tns.json warning

### DIFF
--- a/packages/template-blank-ng/tsconfig.tns.json
+++ b/packages/template-blank-ng/tsconfig.tns.json
@@ -1,7 +1,7 @@
 {
     "extends": "./tsconfig",
     "compilerOptions": {
-        "module": "es2015",
+        "module": "esNext",
         "moduleResolution": "node"
     }
 }

--- a/packages/template-blank-ts/tsconfig.tns.json
+++ b/packages/template-blank-ts/tsconfig.tns.json
@@ -1,7 +1,7 @@
 {
     "extends": "./tsconfig",
     "compilerOptions": {
-        "module": "es2015",
+        "module": "esNext",
         "moduleResolution": "node"
     }
 }

--- a/packages/template-drawer-navigation-ng/tsconfig.tns.json
+++ b/packages/template-drawer-navigation-ng/tsconfig.tns.json
@@ -1,7 +1,7 @@
 {
     "extends": "./tsconfig",
     "compilerOptions": {
-        "module": "es2015",
+        "module": "esNext",
         "moduleResolution": "node"
     }
 }

--- a/packages/template-drawer-navigation-ts/tsconfig.tns.json
+++ b/packages/template-drawer-navigation-ts/tsconfig.tns.json
@@ -1,7 +1,7 @@
 {
     "extends": "./tsconfig",
     "compilerOptions": {
-        "module": "es2015",
+        "module": "esNext",
         "moduleResolution": "node"
     }
 }

--- a/packages/template-health-survey-ng/tsconfig.tns.json
+++ b/packages/template-health-survey-ng/tsconfig.tns.json
@@ -1,7 +1,7 @@
 {
     "extends": "./tsconfig",
     "compilerOptions": {
-        "module": "es2015",
+        "module": "esNext",
         "moduleResolution": "node"
     }
 }

--- a/packages/template-hello-world-ng/tsconfig.tns.json
+++ b/packages/template-hello-world-ng/tsconfig.tns.json
@@ -1,7 +1,7 @@
 {
     "extends": "./tsconfig",
     "compilerOptions": {
-        "module": "es2015",
+        "module": "esNext",
         "moduleResolution": "node"
     }
 }

--- a/packages/template-hello-world-ts/tsconfig.tns.json
+++ b/packages/template-hello-world-ts/tsconfig.tns.json
@@ -1,7 +1,7 @@
 {
     "extends": "./tsconfig",
     "compilerOptions": {
-        "module": "es2015",
+        "module": "esNext",
         "moduleResolution": "node"
     }
 }

--- a/packages/template-master-detail-kinvey-ng/tsconfig.tns.json
+++ b/packages/template-master-detail-kinvey-ng/tsconfig.tns.json
@@ -1,7 +1,7 @@
 {
     "extends": "./tsconfig",
     "compilerOptions": {
-        "module": "es2015",
+        "module": "esNext",
         "moduleResolution": "node"
     }
 }

--- a/packages/template-master-detail-kinvey-ts/tsconfig.tns.json
+++ b/packages/template-master-detail-kinvey-ts/tsconfig.tns.json
@@ -1,7 +1,7 @@
 {
     "extends": "./tsconfig",
     "compilerOptions": {
-        "module": "es2015",
+        "module": "esNext",
         "moduleResolution": "node"
     }
 }

--- a/packages/template-master-detail-ng/tsconfig.tns.json
+++ b/packages/template-master-detail-ng/tsconfig.tns.json
@@ -1,7 +1,7 @@
 {
     "extends": "./tsconfig",
     "compilerOptions": {
-        "module": "es2015",
+        "module": "esNext",
         "moduleResolution": "node"
     }
 }

--- a/packages/template-master-detail-ts/tsconfig.tns.json
+++ b/packages/template-master-detail-ts/tsconfig.tns.json
@@ -1,7 +1,7 @@
 {
     "extends": "./tsconfig",
     "compilerOptions": {
-        "module": "es2015",
+        "module": "esNext",
         "moduleResolution": "node"
     }
 }

--- a/packages/template-patient-care-ng/tsconfig.tns.json
+++ b/packages/template-patient-care-ng/tsconfig.tns.json
@@ -1,7 +1,7 @@
 {
     "extends": "./tsconfig",
     "compilerOptions": {
-        "module": "es2015",
+        "module": "esNext",
         "moduleResolution": "node"
     }
 }

--- a/packages/template-tab-navigation-ng/tsconfig.tns.json
+++ b/packages/template-tab-navigation-ng/tsconfig.tns.json
@@ -1,7 +1,7 @@
 {
     "extends": "./tsconfig",
     "compilerOptions": {
-        "module": "es2015",
+        "module": "esNext",
         "moduleResolution": "node"
     }
 }

--- a/packages/template-tab-navigation-ts/tsconfig.tns.json
+++ b/packages/template-tab-navigation-ts/tsconfig.tns.json
@@ -1,7 +1,7 @@
 {
     "extends": "./tsconfig",
     "compilerOptions": {
-        "module": "es2015",
+        "module": "esNext",
         "moduleResolution": "node"
     }
 }


### PR DESCRIPTION
Address the following warning from nativescript-dev-webpack on `npm install`:
```
> nativescript-dev-webpack@1.2.0 postinstall /Users/x/github/drawer-ts/node_modules/nativescript-dev-webpack
> node postinstall.js

The current project contains a tsconfig.tns.json file located at /Users/x/github/drawer-ts/tsconfig.tns.json that differs from the one in the new version of the nativescript-dev-webpack plugin located at /Users/x/github/drawer-ts/node_modules/nativescript-dev-webpack/templates/tsconfig.tns.json. Some of the plugin features may not work as expected until you manually update the tsconfig.tns.json file or automatically update it using "./node_modules/.bin/update-ns-webpack --configs" command.
```