### PR TITLE
chore(js): remove short import alias

### DIFF
--- a/packages/template-blank-vue/jsconfig.json
+++ b/packages/template-blank-vue/jsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "*": ["./node_modules/tns-core-modules/*", "./node_modules/*"],
       "~/*": ["app/*"]
     }
   },

--- a/packages/template-blank/jsconfig.json
+++ b/packages/template-blank/jsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "*": ["./node_modules/tns-core-modules/*", "./node_modules/*"],
       "~/*": ["app/*"]
     }
   },

--- a/packages/template-drawer-navigation-vue/jsconfig.json
+++ b/packages/template-drawer-navigation-vue/jsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "*": ["./node_modules/tns-core-modules/*", "./node_modules/*"],
       "~/*": ["app/*"]
     }
   },

--- a/packages/template-drawer-navigation/jsconfig.json
+++ b/packages/template-drawer-navigation/jsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "*": ["./node_modules/tns-core-modules/*", "./node_modules/*"],
       "~/*": ["app/*"]
     }
   },

--- a/packages/template-hello-world/jsconfig.json
+++ b/packages/template-hello-world/jsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "*": ["./node_modules/tns-core-modules/*", "./node_modules/*"],
       "~/*": ["app/*"]
     }
   },

--- a/packages/template-master-detail-kinvey/jsconfig.json
+++ b/packages/template-master-detail-kinvey/jsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "*": ["./node_modules/tns-core-modules/*", "./node_modules/*"],
       "~/*": ["app/*"]
     }
   },

--- a/packages/template-master-detail-vue/jsconfig.json
+++ b/packages/template-master-detail-vue/jsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "*": ["./node_modules/tns-core-modules/*", "./node_modules/*"],
       "~/*": ["app/*"]
     }
   },

--- a/packages/template-master-detail/jsconfig.json
+++ b/packages/template-master-detail/jsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "*": ["./node_modules/tns-core-modules/*", "./node_modules/*"],
       "~/*": ["app/*"]
     }
   },

--- a/packages/template-tab-navigation/jsconfig.json
+++ b/packages/template-tab-navigation/jsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "*": ["./node_modules/tns-core-modules/*", "./node_modules/*"],
       "~/*": ["app/*"]
     }
   },


### PR DESCRIPTION
This PR removes the alias for using *short imports* from
`tns-core-modules` from the `jsconfig.json` files.