### PR TITLE
fix(ng-android): runtime compiler not loaded error with aot

### DIFF
--- a/packages/template-blank-ng/src/app/app-routing.module.ts
+++ b/packages/template-blank-ng/src/app/app-routing.module.ts
@@ -4,7 +4,7 @@ import { NativeScriptRouterModule } from "nativescript-angular/router";
 
 const routes: Routes = [
     { path: "", redirectTo: "/home", pathMatch: "full" },
-    { path: "home", loadChildren: () => import(`~/app/home/home.module`).then((m) => m.HomeModule) }
+    { path: "home", loadChildren: () => import("~/app/home/home.module").then((m) => m.HomeModule) }
 ];
 
 @NgModule({

--- a/packages/template-drawer-navigation-ng/src/app/app-routing.module.ts
+++ b/packages/template-drawer-navigation-ng/src/app/app-routing.module.ts
@@ -4,11 +4,11 @@ import { NativeScriptRouterModule } from "nativescript-angular/router";
 
 const routes: Routes = [
     { path: "", redirectTo: "/home", pathMatch: "full" },
-    { path: "home", loadChildren: () => import(`~/app/home/home.module`).then(m => m.HomeModule) },
-    { path: "browse", loadChildren: () => import(`~/app/browse/browse.module`).then(m => m.BrowseModule) },
-    { path: "search", loadChildren: () => import(`~/app/search/search.module`).then(m => m.SearchModule) },
-    { path: "featured", loadChildren: () => import(`~/app/featured/featured.module`).then(m => m.FeaturedModule) },
-    { path: "settings", loadChildren: () => import(`~/app/settings/settings.module`).then(m => m.SettingsModule) }
+    { path: "home", loadChildren: () => import("~/app/home/home.module").then(m => m.HomeModule) },
+    { path: "browse", loadChildren: () => import("~/app/browse/browse.module").then(m => m.BrowseModule) },
+    { path: "search", loadChildren: () => import("~/app/search/search.module").then(m => m.SearchModule) },
+    { path: "featured", loadChildren: () => import("~/app/featured/featured.module").then(m => m.FeaturedModule) },
+    { path: "settings", loadChildren: () => import("~/app/settings/settings.module").then(m => m.SettingsModule) }
 ];
 
 @NgModule({

--- a/packages/template-health-survey-ng/src/app/app-routing.module.ts
+++ b/packages/template-health-survey-ng/src/app/app-routing.module.ts
@@ -6,9 +6,9 @@ import { LoggedInLazyLoadGuard } from "./logged-in-lazy-load.guard";
 
 const routes: Routes = [
     { path: "", redirectTo: "/consent", pathMatch: "full" },
-    { path: "login", loadChildren: () => import(`~/app/login/login.module`).then((m) => m.LoginModule) },
-    { path: "consent", loadChildren: () => import(`~/app/consent/consent.module`).then((m) => m.ConsentModule), canLoad: [LoggedInLazyLoadGuard] },
-    { path: "survey", loadChildren: () => import(`~/app/survey/survey.module`).then((m) => m.SurveyModule) }
+    { path: "login", loadChildren: () => import("~/app/login/login.module").then((m) => m.LoginModule) },
+    { path: "consent", loadChildren: () => import("~/app/consent/consent.module").then((m) => m.ConsentModule), canLoad: [LoggedInLazyLoadGuard] },
+    { path: "survey", loadChildren: () => import("~/app/survey/survey.module").then((m) => m.SurveyModule) }
 ];
 
 @NgModule({

--- a/packages/template-master-detail-kinvey-ng/src/app/app-routing.module.ts
+++ b/packages/template-master-detail-kinvey-ng/src/app/app-routing.module.ts
@@ -4,7 +4,7 @@ import { NativeScriptRouterModule } from "nativescript-angular/router";
 
 const routes: Routes = [
     { path: "", redirectTo: "/cars", pathMatch: "full" },
-    { path: "cars", loadChildren: () => import(`~/app/cars/cars.module`).then((m) => m.CarsModule) }
+    { path: "cars", loadChildren: () => import("~/app/cars/cars.module").then((m) => m.CarsModule) }
 ];
 
 @NgModule({

--- a/packages/template-master-detail-ng/src/app/app-routing.module.ts
+++ b/packages/template-master-detail-ng/src/app/app-routing.module.ts
@@ -4,7 +4,7 @@ import { NativeScriptRouterModule } from "nativescript-angular/router";
 
 const routes: Routes = [
     { path: "", redirectTo: "/cars", pathMatch: "full" },
-    { path: "cars", loadChildren: () => import(`~/app/cars/cars.module`).then((m) => m.CarsModule) }
+    { path: "cars", loadChildren: () => import("~/app/cars/cars.module").then((m) => m.CarsModule) }
 ];
 
 @NgModule({

--- a/packages/template-patient-care-ng/src/app-routing.module.ts
+++ b/packages/template-patient-care-ng/src/app-routing.module.ts
@@ -6,8 +6,8 @@ import { LoggedInLazyLoadGuard } from "./logged-in-lazy-load.guard";
 
 const routes: Routes = [
     { path: "", redirectTo: "/care", pathMatch: "full" },
-    { path: "care", loadChildren: () => import(`./care/care.module`).then((m) => m.CareModule), canLoad: [LoggedInLazyLoadGuard] },
-    { path: "login", loadChildren: () => import(`./login/login.module`).then((m) => m.LoginModule) }
+    { path: "care", loadChildren: () => import("./care/care.module").then((m) => m.CareModule), canLoad: [LoggedInLazyLoadGuard] },
+    { path: "login", loadChildren: () => import("./login/login.module").then((m) => m.LoginModule) }
 ];
 
 @NgModule({

--- a/packages/template-tab-navigation-ng/src/app/app-routing.module.ts
+++ b/packages/template-tab-navigation-ng/src/app/app-routing.module.ts
@@ -13,19 +13,19 @@ const routes: Routes = [
     {
         path: "home",
         component: NSEmptyOutletComponent,
-        loadChildren: () => import(`~/app/home/home.module`).then((m) => m.HomeModule),
+        loadChildren: () => import("~/app/home/home.module").then((m) => m.HomeModule),
         outlet: "homeTab"
     },
     {
         path: "browse",
         component: NSEmptyOutletComponent,
-        loadChildren: () => import(`~/app/browse/browse.module`).then((m) => m.BrowseModule),
+        loadChildren: () => import("~/app/browse/browse.module").then((m) => m.BrowseModule),
         outlet: "browseTab"
     },
     {
         path: "search",
         component: NSEmptyOutletComponent,
-        loadChildren: () => import(`~/app/search/search.module`).then((m) => m.SearchModule),
+        loadChildren: () => import("~/app/search/search.module").then((m) => m.SearchModule),
         outlet: "searchTab"
     }
 ];


### PR DESCRIPTION
Fixes `Runtime is not loaded` error in Angular Android templates with --env.aot option specified:
```
Restarting application on device emulator-5562...
Successfully synced application org.nativescript.TestApp on device emulator-5562.
ActivityManager: Start proc 3732:org.nativescript.TestApp/u0a55 for activity org.nativescript.TestApp/com.tns.NativeScriptActivity
JS: HMR: Hot Module Replacement Enabled. Waiting for signal.
JS: Angular is running in the development mode. Call enableProdMode() to enable the production mode.
JS: firebase.init done
JS: ERROR Error: Uncaught (in promise): Error: Runtime compiler is not loaded
JS: Error: Runtime compiler is not loaded
JS:     at Compiler._throwError (file:///node_modules/@angular/core/fesm5/core.js:25788:0) [angular]
JS:     at MergeMapSubscriber.project (file:///node_modules/@angular/router/fesm5/router.js:3613:31) [angular]
JS:     at MergeMapSubscriber.push.../node_modules/rxjs/_esm5/internal/operators/mergeMap.js.MergeMapSubscriber._tryNext (file:///node_modules/rxjs/_esm5/internal/operators/mergeMap.js:61:0) [angular]
JS:     at MergeMapSubscriber.push.../node_modules/rxjs/_esm5/internal/operators/mergeMap.js.MergeMapSubscriber._next (file:///node_modules/rxjs/_esm5/internal/operators/mergeMap.js:51:0) [angular]
JS:     at MergeMapSubscriber.push.../node_modules/rxjs/_esm5/internal/Subscriber.js.Subscriber.next (file:///node_modules/rxjs/_esm5/internal/Subscriber.js:53:0) [angular]
JS:     at file:///node_modules/rxjs/_esm5/internal/util/subscribeToPromise.js:7:0 [angular]
JS:     at Object...
```

See https://angular.io/guide/deprecations#loadchildren-string-syntax
Related to: https://github.com/NativeScript/nativescript-app-templates/pull/93