### PR TITLE
fix: hardcode light mode temporarily

### DIFF
--- a/packages/template-health-survey-ng/App_Resources/iOS/Info.plist
+++ b/packages/template-health-survey-ng/App_Resources/iOS/Info.plist
@@ -22,6 +22,8 @@
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiresFullScreen</key>

--- a/packages/template-patient-care-ng/App_Resources/iOS/Info.plist
+++ b/packages/template-patient-care-ng/App_Resources/iOS/Info.plist
@@ -22,6 +22,8 @@
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiresFullScreen</key>


### PR DESCRIPTION
Temporarily hardcode light mode for health survey & patient care templates as we will not be able to migrate them to theme v2 for {N} 6.2.0 release.