### PR TITLE
fix: broken vscode extension recommendation

### DIFF
--- a/packages/template-blank-ng/tools/vscode.extensions.json
+++ b/packages/template-blank-ng/tools/vscode.extensions.json
@@ -1,5 +1,5 @@
 {
 	"recommendations": [
-		"telerik.nativescript"
+		"nativescript.nativescript"
 	]
 }

--- a/packages/template-blank-react/hooks/after-createProject/after-createProject.js
+++ b/packages/template-blank-react/hooks/after-createProject/after-createProject.js
@@ -10,7 +10,7 @@ module.exports = function (hookArgs) {
     const vscodeDir = path.join(appRootFolder, ".vscode");
     const srcGitignore = path.join(toolsDir, "dot.gitignore");
     const destGitignore = path.join(appRootFolder, ".gitignore");
-    // I'll continue to copy this file across, but omit the recommendation for "telerik.nativescript" as that's Core-focused.
+    // I'll continue to copy this file across, but omit the recommendation for "nativescript.nativescript" as that's Core-focused.
     const srcVscodeExtensions = path.join(toolsDir, "vscode.extensions.json");
     const destVscodeExtensions = path.join(vscodeDir, "extensions.json");
 
@@ -26,7 +26,7 @@ module.exports = function (hookArgs) {
 
             const readme = path.join(appRootFolder, "README.md");
             fs.unlinkSync(readme);
-    
+
             deleteFolderSync(__dirname);
         } catch (error) {
             console.log(error);

--- a/packages/template-blank-svelte/tools/vscode.extensions.json
+++ b/packages/template-blank-svelte/tools/vscode.extensions.json
@@ -1,5 +1,5 @@
 {
 	"recommendations": [
-		"telerik.nativescript"
+		"nativescript.nativescript"
 	]
 }

--- a/packages/template-blank-ts/tools/vscode.extensions.json
+++ b/packages/template-blank-ts/tools/vscode.extensions.json
@@ -1,5 +1,5 @@
 {
 	"recommendations": [
-		"telerik.nativescript"
+		"nativescript.nativescript"
 	]
 }

--- a/packages/template-blank-vue/tools/vscode.extensions.json
+++ b/packages/template-blank-vue/tools/vscode.extensions.json
@@ -1,5 +1,5 @@
 {
 	"recommendations": [
-		"telerik.nativescript"
+		"nativescript.nativescript"
 	]
 }

--- a/packages/template-blank/tools/vscode.extensions.json
+++ b/packages/template-blank/tools/vscode.extensions.json
@@ -1,5 +1,5 @@
 {
 	"recommendations": [
-		"telerik.nativescript"
+		"nativescript.nativescript"
 	]
 }

--- a/packages/template-drawer-navigation-ng/tools/vscode.extensions.json
+++ b/packages/template-drawer-navigation-ng/tools/vscode.extensions.json
@@ -1,5 +1,5 @@
 {
 	"recommendations": [
-		"telerik.nativescript"
+		"nativescript.nativescript"
 	]
 }

--- a/packages/template-drawer-navigation-ts/tools/vscode.extensions.json
+++ b/packages/template-drawer-navigation-ts/tools/vscode.extensions.json
@@ -1,5 +1,5 @@
 {
 	"recommendations": [
-		"telerik.nativescript"
+		"nativescript.nativescript"
 	]
 }

--- a/packages/template-drawer-navigation-vue/tools/vscode.extensions.json
+++ b/packages/template-drawer-navigation-vue/tools/vscode.extensions.json
@@ -1,5 +1,5 @@
 {
 	"recommendations": [
-		"telerik.nativescript"
+		"nativescript.nativescript"
 	]
 }

--- a/packages/template-drawer-navigation/tools/vscode.extensions.json
+++ b/packages/template-drawer-navigation/tools/vscode.extensions.json
@@ -1,5 +1,5 @@
 {
 	"recommendations": [
-		"telerik.nativescript"
+		"nativescript.nativescript"
 	]
 }

--- a/packages/template-hello-world-ng/tools/vscode.extensions.json
+++ b/packages/template-hello-world-ng/tools/vscode.extensions.json
@@ -1,5 +1,5 @@
 {
 	"recommendations": [
-		"telerik.nativescript"
+		"nativescript.nativescript"
 	]
 }

--- a/packages/template-hello-world-ts/tools/vscode.extensions.json
+++ b/packages/template-hello-world-ts/tools/vscode.extensions.json
@@ -1,5 +1,5 @@
 {
 	"recommendations": [
-		"telerik.nativescript"
+		"nativescript.nativescript"
 	]
 }

--- a/packages/template-hello-world/tools/vscode.extensions.json
+++ b/packages/template-hello-world/tools/vscode.extensions.json
@@ -1,5 +1,5 @@
 {
 	"recommendations": [
-		"telerik.nativescript"
+		"nativescript.nativescript"
 	]
 }

--- a/packages/template-master-detail-ng/tools/vscode.extensions.json
+++ b/packages/template-master-detail-ng/tools/vscode.extensions.json
@@ -1,5 +1,5 @@
 {
 	"recommendations": [
-		"telerik.nativescript"
+		"nativescript.nativescript"
 	]
 }

--- a/packages/template-master-detail-ts/tools/vscode.extensions.json
+++ b/packages/template-master-detail-ts/tools/vscode.extensions.json
@@ -1,5 +1,5 @@
 {
 	"recommendations": [
-		"telerik.nativescript"
+		"nativescript.nativescript"
 	]
 }

--- a/packages/template-master-detail-vue/tools/vscode.extensions.json
+++ b/packages/template-master-detail-vue/tools/vscode.extensions.json
@@ -1,5 +1,5 @@
 {
 	"recommendations": [
-		"telerik.nativescript"
+		"nativescript.nativescript"
 	]
 }

--- a/packages/template-master-detail/tools/vscode.extensions.json
+++ b/packages/template-master-detail/tools/vscode.extensions.json
@@ -1,5 +1,5 @@
 {
 	"recommendations": [
-		"telerik.nativescript"
+		"nativescript.nativescript"
 	]
 }

--- a/packages/template-tab-navigation-ng/tools/vscode.extensions.json
+++ b/packages/template-tab-navigation-ng/tools/vscode.extensions.json
@@ -1,5 +1,5 @@
 {
 	"recommendations": [
-		"telerik.nativescript"
+		"nativescript.nativescript"
 	]
 }

--- a/packages/template-tab-navigation-ts/tools/vscode.extensions.json
+++ b/packages/template-tab-navigation-ts/tools/vscode.extensions.json
@@ -1,5 +1,5 @@
 {
 	"recommendations": [
-		"telerik.nativescript"
+		"nativescript.nativescript"
 	]
 }

--- a/packages/template-tab-navigation-vue/tools/vscode.extensions.json
+++ b/packages/template-tab-navigation-vue/tools/vscode.extensions.json
@@ -1,5 +1,5 @@
 {
 	"recommendations": [
-		"telerik.nativescript"
+		"nativescript.nativescript"
 	]
 }

--- a/packages/template-tab-navigation/tools/vscode.extensions.json
+++ b/packages/template-tab-navigation/tools/vscode.extensions.json
@@ -1,5 +1,5 @@
 {
 	"recommendations": [
-		"telerik.nativescript"
+		"nativescript.nativescript"
 	]
 }


### PR DESCRIPTION
just a tiny small fix :)

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.

## What is the current behavior?
Any new project (except template-blank-react) created with an template get's a vscode extension recommendation, which is currently refering to "telerik.nativescript", which is now listed under "nativescript.nativescript". That results in a small warning box:

![Screenshot 2020-10-26 at 21 43 10](https://user-images.githubusercontent.com/5492730/97227510-e0af7480-17d5-11eb-9411-557cc7ac2dc1.png)

## What is the new behavior?
The recommended extension is now "nativescript.nativescript"

