### PR TITLE
fix: Renamed RNS Navigation exports

### DIFF
--- a/packages/template-blank-react/package.json
+++ b/packages/template-blank-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nativescript/template-blank-react",
-  "version": "7.0.6",
+  "version": "7.0.7",
   "description": "Blank template for NativeScript apps using React.",
   "author": "Jamie Birch <14055146+shirakaba@users.noreply.github.com>",
   "main": "app.js",

--- a/packages/template-blank-react/src/components/FirstScreen.tsx
+++ b/packages/template-blank-react/src/components/FirstScreen.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
 import { RouteProp } from '@react-navigation/core';
 import { Dialogs } from '@nativescript/core';
-import { NativeStackNavigationProp } from "react-nativescript-navigation";
+import { FrameNavigationProp } from "react-nativescript-navigation";
 import { MainStackParamList } from "./NavigationParamList";
 
 type FirstScreenProps = {
     route: RouteProp<MainStackParamList, "first">,
-    navigation: NativeStackNavigationProp<MainStackParamList, "first">,
+    navigation: FrameNavigationProp<MainStackParamList, "first">,
 }
 
 export function First({ navigation }: FirstScreenProps) {

--- a/packages/template-blank-react/src/components/SecondScreen.tsx
+++ b/packages/template-blank-react/src/components/SecondScreen.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { RouteProp } from '@react-navigation/core';
-import { NativeStackNavigationProp } from "react-nativescript-navigation";
+import { FrameNavigationProp } from "react-nativescript-navigation";
 import { MainStackParamList } from "./NavigationParamList";
 
 type SecondScreenProps = {
     route: RouteProp<MainStackParamList, "second">,
-    navigation: NativeStackNavigationProp<MainStackParamList, "second">,
+    navigation: FrameNavigationProp<MainStackParamList, "second">,
 }
 
 export function Second({ navigation }: SecondScreenProps) {


### PR DESCRIPTION
RNS Navigation v2 renames an import, which I neglected to take care of in the last PR.