### PR TITLE
Fix/restore hmr for rns

### DIFF
--- a/packages/template-blank-react/package.json
+++ b/packages/template-blank-react/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@babel/core": "^7.4.5",
     "@nativescript/types": "^7.0.4",
-    "@nativescript/webpack": "~3.0.0",
+    "@nativescript/webpack": "^4.0.0",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.4.0-beta.5",
     "@types/react": "16.9.34",
     "babel-loader": "8.0.6",

--- a/packages/template-blank-react/package.json
+++ b/packages/template-blank-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nativescript/template-blank-react",
-  "version": "7.0.8",
+  "version": "7.0.9",
   "description": "Blank template for NativeScript apps using React.",
   "author": "Jamie Birch <14055146+shirakaba@users.noreply.github.com>",
   "main": "app.js",

--- a/packages/template-blank-react/webpack.config.js
+++ b/packages/template-blank-react/webpack.config.js
@@ -67,12 +67,6 @@ module.exports = (env) => {
     );
 
     if(hmr && !production){
-        console.warn(
-            `[webpack.config.js] Warning: You have enabled HMR. However, as of the NativeScript 7 template updates, it ` + 
-            `is broken, due to an issue in CopyWebpackPlugin. Please follow the instructions in this issue thread to roll ` +
-            `back CopyWebpackPlugin to v4.6.0 and restore HMR: https://github.com/shirakaba/react-nativescript/issues/65\n` +
-            `... After that, feel free to delete this warning from webpack.config.js!`
-        );
         baseConfig.plugins.push(new ReactRefreshWebpackPlugin({
             /**
              * Maybe one day we'll implement an Error Overlay, but the work involved is too daunting for now.


### PR DESCRIPTION
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.

Note: The link for CONTRIBUTING.md is broken.
Note: RNS doesn't have any tests, so it passes all of them

## What is the current behavior?

HMR broken

## What is the new behavior?

HMR less broken

Fixes/Implements/Closes:

https://github.com/shirakaba/react-nativescript/issues/65

BREAKING CHANGES:

None, as this will provide the correct webpack config for newly generated projects.

Migration steps:

Existing applications could apply the same fix by updating to `@nativescript/webpack@4.0.0` replacing their existing `webpack.typescript.js` with the one from `@nativescript/webpack@4.0.0`.