### PR TITLE
fix: package.json wrong entrypoint in template

### DIFF
--- a/packages/template-drawer-navigation-ts/package.json
+++ b/packages/template-drawer-navigation-ts/package.json
@@ -3,7 +3,7 @@
   "main": "main.js",
   "displayName": "Navigation Drawer",
   "templateType": "App template",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "description": "Side navigation template",
   "author": "NativeScript Team <oss@nativescript.org>",
   "license": "Apache-2.0",

--- a/packages/template-drawer-navigation-ts/package.json
+++ b/packages/template-drawer-navigation-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nativescript/template-drawer-navigation-ts",
-  "main": "app.js",
+  "main": "main.js",
   "displayName": "Navigation Drawer",
   "templateType": "App template",
   "version": "7.0.3",


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.

## What is the current behavior?
The Build fails because the entry point does not exists

## What is the new behavior?
Build ends successfully
Fixes/Implements/Closes #[Issue Number].

- Fix Package.json main entry point

