### PR TITLE
fix: missing template-blank-vue-ts afterCreate hooks

### DIFF
--- a/packages/template-blank-vue-ts/.gitignore
+++ b/packages/template-blank-vue-ts/.gitignore
@@ -5,5 +5,6 @@
 node_modules
 
 # NativeScript application
-hooks
+hooks/*
+!hooks/after-createProject/after-createProject.js
 platforms

--- a/packages/template-blank-vue-ts/hooks/after-createProject/after-createProject.js
+++ b/packages/template-blank-vue-ts/hooks/after-createProject/after-createProject.js
@@ -1,0 +1,48 @@
+const fs = require("fs");
+const path = require("path");
+
+module.exports = function (hookArgs) {
+    const appRootFolder = hookArgs.projectDir;
+    const toolsDir = path.join(appRootFolder, "tools");
+    const vscodeDir = path.join(appRootFolder, ".vscode");
+    const srcGitignore = path.join(toolsDir, "dot.gitignore");
+    const destGitignore = path.join(appRootFolder, ".gitignore");
+    const srcVscodeExtensions = path.join(toolsDir, "vscode.extensions.json");
+    const destVscodeExtensions = path.join(vscodeDir, "extensions.json");
+
+    try {
+        fs.mkdirSync(vscodeDir);
+        fs.copyFileSync(srcVscodeExtensions, destVscodeExtensions);
+        fs.copyFileSync(srcGitignore, destGitignore);
+    } catch (error) {
+        console.log(error);
+    } finally {
+        try {
+            deleteFolderSync(toolsDir);
+
+            const readme = path.join(appRootFolder, "README.md");
+            fs.unlinkSync(readme);
+    
+            deleteFolderSync(__dirname);
+        } catch (error) {
+            console.log(error);
+        }
+    }
+
+    function deleteFolderSync(folderPath) {
+        if (fs.statSync(folderPath).isDirectory()) {
+            fs.readdirSync(folderPath).forEach((file) => {
+                const content = path.join(folderPath, file);
+                const contentDirs = fs.statSync(content).isDirectory();
+
+                if (contentDirs) {
+                    deleteFolderSync(content);
+                } else {
+                    fs.unlinkSync(content);
+                }
+            });
+
+            fs.rmdirSync(folderPath);
+        }
+    }
+};

--- a/packages/template-blank-vue-ts/package.json
+++ b/packages/template-blank-vue-ts/package.json
@@ -2,7 +2,7 @@
   "name": "@nativescript/template-blank-vue-ts",
   "main": "app.js",
   "displayName": "Blank Vue Typescript",
-  "version": "7.0.4",
+  "version": "7.0.5",
   "description": "Blank Typescript template for NativeScript apps using Vue.",
   "author": "NativeScript Team <oss@nativescript.org>",
   "license": "Apache-2.0",


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
Added `after-createProject.js` to hooks


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

