### PR TITLE
Fix ng templates missing polyfils

### DIFF
--- a/packages/template-drawer-navigation-ng/src/polyfills.ts
+++ b/packages/template-drawer-navigation-ng/src/polyfills.ts
@@ -1,0 +1,20 @@
+/**
+ * NativeScript Polyfills
+ */
+
+// Install @nativescript/core polyfills (XHR, setTimeout, requestAnimationFrame)
+import '@nativescript/core/globals';
+// Install @nativescript/angular specific polyfills
+import '@nativescript/angular/polyfills';
+
+/**
+ * Zone.js and patches
+ */
+// Add pre-zone.js patches needed for the NativeScript platform
+import '@nativescript/zone-js/dist/pre-zone-polyfills';
+
+// Zone JS is required by default for Angular itself
+import 'zone.js';
+
+// Add NativeScript specific Zone JS patches
+import '@nativescript/zone-js';

--- a/packages/template-drawer-navigation-ng/tsconfig.json
+++ b/packages/template-drawer-navigation-ng/tsconfig.json
@@ -16,6 +16,6 @@
     }
   },
   "include": ["./src/**/*.ios.ts", "./src/**/*.android.ts"],
-  "files": ["./src/main.ts", "./references.d.ts"],
+  "files": ["./src/main.ts", "./references.d.ts", "./src/polyfills.ts"],
   "exclude": ["node_modules", "platforms"]
 }

--- a/packages/template-tab-navigation-ng/src/polyfills.ts
+++ b/packages/template-tab-navigation-ng/src/polyfills.ts
@@ -1,0 +1,20 @@
+/**
+ * NativeScript Polyfills
+ */
+
+// Install @nativescript/core polyfills (XHR, setTimeout, requestAnimationFrame)
+import '@nativescript/core/globals';
+// Install @nativescript/angular specific polyfills
+import '@nativescript/angular/polyfills';
+
+/**
+ * Zone.js and patches
+ */
+// Add pre-zone.js patches needed for the NativeScript platform
+import '@nativescript/zone-js/dist/pre-zone-polyfills';
+
+// Zone JS is required by default for Angular itself
+import 'zone.js';
+
+// Add NativeScript specific Zone JS patches
+import '@nativescript/zone-js';

--- a/packages/template-tab-navigation-ng/tsconfig.json
+++ b/packages/template-tab-navigation-ng/tsconfig.json
@@ -15,7 +15,7 @@
       "@/*": ["src/*"]
     }
   },
-  "include": ["src/**/*.android.ts", "src/**/*.ios.ts"],
-  "files": ["./src/main.ts", "./references.d.ts"],
-  "exclude": ["node_modules", "platforms", "e2e"]
+  "include": ["./src/**/*.ios.ts", "./src/**/*.android.ts"],
+  "files": ["./src/main.ts", "./references.d.ts", "./src/polyfills.ts"],
+  "exclude": ["node_modules", "platforms"]
 }


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.

## What is the current behavior?
polyfills missing from these ng templates.
## What is the new behavior?
ns create should result in a runnable project using these templates

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

