### PR TITLE
fix: add polyfill and remove error when running app

### DIFF
--- a/packages/template-master-detail-ng/src/app/cars/car-list.component.html
+++ b/packages/template-master-detail-ng/src/app/cars/car-list.component.html
@@ -15,11 +15,11 @@
     <ng-template tkListItemTemplate let-car="item">
       <StackLayout class="cars-list__item">
         <GridLayout rows="*, *, *" columns="*, *" class="cars-list__item-content">
-          <Label [text]="car.name" class="cars-list__item-name font-weight-bold"></Label>
+          <Label [text]="car?.name" class="cars-list__item-name font-weight-bold"></Label>
           <Label col="1" horizontalAlignment="right" class="m-r-5">
             <FormattedString>
               <Span text="&euro;"></Span>
-              <Span [text]="car.price"></Span>
+              <Span [text]="car?.price"></Span>
               <Span text="/day"></Span>
             </FormattedString>
           </Label>
@@ -28,7 +28,7 @@
 
           <Image
             row="2"
-            [src]="car.imageUrl"
+            [src]="car?.imageUrl"
             stretch="aspectFill"
             height="120"
             class="m-r-20"
@@ -38,14 +38,14 @@
               <!-- set fontFamily="system" to workaround "Service exited due to Segmentation fault: 11" error -->
               <FormattedString ios:fontFamily="system">
                 <Span text="&#xf1b9;    " class="fas cars-list__item-icon"></Span>
-                <Span [text]="car.class"></Span>
+                <Span [text]="car?.class"></Span>
               </FormattedString>
             </Label>
             <Label class="p-b-10">
               <!-- set fontFamily="system" to workaround "Service exited due to Segmentation fault: 11" error -->
               <FormattedString ios:fontFamily="system">
                 <Span text="&#xf085;   " class="fas cars-list__item-icon"></Span>
-                <Span [text]="car.transmission"></Span>
+                <Span [text]="car?.transmission"></Span>
                 <Span text=" Transmission"></Span>
               </FormattedString>
             </Label>
@@ -53,7 +53,7 @@
               <!-- set fontFamily="system" to workaround "Service exited due to Segmentation fault: 11" error -->
               <FormattedString ios:fontFamily="system">
                 <Span text="&#xf2dc;    " class="fas cars-list__item-icon"></Span>
-                <Span [text]="car.hasAC ? 'Yes' : 'No'"></Span>
+                <Span [text]="car?.hasAC ? 'Yes' : 'No'"></Span>
               </FormattedString>
             </Label>
           </StackLayout>

--- a/packages/template-master-detail-ng/src/polyfills.ts
+++ b/packages/template-master-detail-ng/src/polyfills.ts
@@ -1,0 +1,20 @@
+/**
+ * NativeScript Polyfills
+ */
+
+// Install @nativescript/core polyfills (XHR, setTimeout, requestAnimationFrame)
+import '@nativescript/core/globals';
+// Install @nativescript/angular specific polyfills
+import '@nativescript/angular/polyfills';
+
+/**
+ * Zone.js and patches
+ */
+// Add pre-zone.js patches needed for the NativeScript platform
+import '@nativescript/zone-js/dist/pre-zone-polyfills';
+
+// Zone JS is required by default for Angular itself
+import 'zone.js';
+
+// Add NativeScript specific Zone JS patches
+import '@nativescript/zone-js';

--- a/packages/template-master-detail-ng/tsconfig.json
+++ b/packages/template-master-detail-ng/tsconfig.json
@@ -16,6 +16,6 @@
     }
   },
   "include": ["./src/**/*.android.ts", "./src/**/*.ios.ts"],
-  "files": ["./src/main.ts", "./references.d.ts"],
+  "files": ["./src/main.ts", "./references.d.ts", "./src/polyfills.ts"],
   "exclude": ["node_modules", "platforms"]
 }


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.

## What is the current behavior?
Polyfill missing from template and ```ERROR TypeError: Cannot read property 'name' of undefined``` error is logged when running app.

## What is the new behavior?
Resulting app runs ok.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

