### PR TITLE
chore(template-blank-react): more react-refresh to webpack5

### DIFF
--- a/packages/template-blank-react/package.json
+++ b/packages/template-blank-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nativescript/template-blank-react",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "description": "Blank template for NativeScript apps using React.",
   "author": "Jamie Birch <14055146+shirakaba@users.noreply.github.com>",
   "main": "src/app.ts",

--- a/packages/template-blank-react/package.json
+++ b/packages/template-blank-react/package.json
@@ -45,13 +45,11 @@
     "@react-navigation/core": "^5.15.3",
     "react": "~16.13.1",
     "react-nativescript": "^3.0.0-beta.1",
-    "react-nativescript-navigation": "3.0.0-beta.2",
-    "react-refresh": "~0.8.3"
+    "react-nativescript-navigation": "3.0.0-beta.2"
   },
   "devDependencies": {
     "@nativescript/types": "~8.1.1",
     "@nativescript/webpack": "~5.0.0",
-    "@pmmmwh/react-refresh-webpack-plugin": "~0.4.0-beta.5",
     "@types/react": "16.9.34",
     "patch-package": "~6.2.2",
     "typescript": "~4.3.5"


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`react-refresh` has duplicate dependencies across the projects and `@nativescript/webpack@5`

## What is the new behavior?
<!-- Describe the changes. -->
`react-refresh` is now an internal dependencies of `@nativescript/webpack@5` and is not a dependencies of the projects themselves.

