### PR TITLE
chore: upgrade templates to TypeScript 6 and NS 9.1

### DIFF
--- a/packages/template-blank-ng/package.json
+++ b/packages/template-blank-ng/package.json
@@ -3,7 +3,7 @@
   "main": "src/main.ts",
   "displayName": "Blank",
   "templateType": "App template",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "Blank template for NativeScript apps using Angular",
   "author": "NativeScript Team <oss@nativescript.org>",
   "license": "Apache-2.0",

--- a/packages/template-blank-ng/package.json
+++ b/packages/template-blank-ng/package.json
@@ -48,10 +48,10 @@
     "@angular/platform-browser": "~22.0.0",
     "@angular/platform-browser-dynamic": "~22.0.0",
     "@angular/router": "~22.0.0",
-    "@nativescript/angular": "^21.0.0",
-    "@nativescript/core": "~9.0.0",
+    "@nativescript/angular": "~22.0.0",
+    "@nativescript/core": "~9.1.0",
     "rxjs": "~7.8.0",
-    "zone.js": "~0.15.0"
+    "zone.js": "~0.16.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~22.0.0",

--- a/packages/template-blank-ng/package.json
+++ b/packages/template-blank-ng/package.json
@@ -40,27 +40,27 @@
     "url": "https://github.com/NativeScript/NativeScript/issues"
   },
   "dependencies": {
-    "@angular/animations": "~20.2.0",
-    "@angular/common": "~20.2.0",
-    "@angular/compiler": "~20.2.0",
-    "@angular/core": "~20.2.0",
-    "@angular/forms": "~20.2.0",
-    "@angular/platform-browser": "~20.2.0",
-    "@angular/platform-browser-dynamic": "~20.2.0",
-    "@angular/router": "~20.2.0",
-    "@nativescript/angular": "^20.0.0",
+    "@angular/animations": "~22.0.0",
+    "@angular/common": "~22.0.0",
+    "@angular/compiler": "~22.0.0",
+    "@angular/core": "~22.0.0",
+    "@angular/forms": "~22.0.0",
+    "@angular/platform-browser": "~22.0.0",
+    "@angular/platform-browser-dynamic": "~22.0.0",
+    "@angular/router": "~22.0.0",
+    "@nativescript/angular": "^21.0.0",
     "@nativescript/core": "~9.0.0",
     "rxjs": "~7.8.0",
     "zone.js": "~0.15.0"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "~20.2.0",
-    "@angular/compiler-cli": "~20.2.0",
+    "@angular-devkit/build-angular": "~22.0.0",
+    "@angular/compiler-cli": "~22.0.0",
     "@nativescript/tailwind": "^2.1.0",
     "@nativescript/types": "~9.0.0",
     "@nativescript/webpack": "~5.0.25",
-    "@ngtools/webpack": "~20.2.0",
+    "@ngtools/webpack": "~22.0.0",
     "tailwindcss": "~3.4.0",
-    "typescript": "~5.8.0"
+    "typescript": "~6.0.0"
   }
 }

--- a/packages/template-blank-ng/tsconfig.json
+++ b/packages/template-blank-ng/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": false,
     "module": "esnext",
     "target": "ES2020",
     "moduleResolution": "bundler",
@@ -9,10 +10,9 @@
     "noEmitOnError": true,
     "skipLibCheck": true,
     "lib": ["ESNext", "dom"],
-    "baseUrl": ".",
     "paths": {
-      "~/*": ["src/*"],
-      "@/*": ["src/*"]
+      "~/*": ["./src/*"],
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src/tests/**/*.ts", "src/**/*.ios.ts", "src/**/*.android.ts"],

--- a/packages/template-blank-react-vision/package.json
+++ b/packages/template-blank-react-vision/package.json
@@ -52,7 +52,7 @@
     "@nativescript/webpack": "~5.0.25",
     "@types/react": "npm:types-react-without-jsx-intrinsics@^18.0.17",
     "tailwindcss": "~3.4.0",
-    "typescript": "~5.4.0"
+    "typescript": "~6.0.0"
   },
   "gitHead": "1350d382fb4b0ed4c6e9685df909518b2688e004",
   "readme": "NativeScript Application"

--- a/packages/template-blank-react-vision/package.json
+++ b/packages/template-blank-react-vision/package.json
@@ -41,7 +41,7 @@
     "Vision Pro"
   ],
   "dependencies": {
-    "@nativescript/core": "~9.0.0",
+    "@nativescript/core": "~9.1.0",
     "react": "^18.2.0",
     "react-nativescript": "^5.0.0",
     "react-nativescript-navigation": "^5.0.0"

--- a/packages/template-blank-react-vision/package.json
+++ b/packages/template-blank-react-vision/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nativescript/template-blank-react-vision",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "Nativescript visionOS Starter with React",
   "author": "Jamie Birch <14055146+shirakaba@users.noreply.github.com>",
   "main": "src/app.ts",

--- a/packages/template-blank-react-vision/tsconfig.json
+++ b/packages/template-blank-react-vision/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": false,
     "module": "esnext",
     "target": "ES2020",
     "moduleResolution": "bundler",
@@ -7,12 +8,12 @@
     "emitDecoratorMetadata": true,
     "noEmitHelpers": true,
     "noEmitOnError": true,
+    "skipLibCheck": true,
     "jsx": "react",
     "lib": ["ESNext", "dom"],
-    "baseUrl": ".",
     "paths": {
-      "~/*": ["src/*"],
-      "@/*": ["src/*"]
+      "~/*": ["./src/*"],
+      "@/*": ["./src/*"]
     }
   },
   "include": ["./src/**/*.tsx?"],

--- a/packages/template-blank-react/package.json
+++ b/packages/template-blank-react/package.json
@@ -48,7 +48,7 @@
     "@nativescript/types": "~9.0.0",
     "@nativescript/webpack": "~5.0.28",
     "@types/react": "npm:types-react-without-jsx-intrinsics@^18.0.17",
-    "typescript": "~5.4.0"
+    "typescript": "~6.0.0"
   },
   "overrides": {
     "@nativescript/core": "~9.0.0"

--- a/packages/template-blank-react/package.json
+++ b/packages/template-blank-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nativescript/template-blank-react",
-  "version": "9.0.4",
+  "version": "9.1.0",
   "description": "Blank template for NativeScript apps using React.",
   "author": "Jamie Birch <14055146+shirakaba@users.noreply.github.com>",
   "main": "src/app.ts",

--- a/packages/template-blank-react/package.json
+++ b/packages/template-blank-react/package.json
@@ -39,7 +39,7 @@
     "template"
   ],
   "dependencies": {
-    "@nativescript/core": "~9.0.0",
+    "@nativescript/core": "~9.1.0",
     "react": "^18.2.0",
     "react-nativescript": "^5.0.0",
     "react-nativescript-navigation": "^5.0.0"
@@ -51,7 +51,7 @@
     "typescript": "~6.0.0"
   },
   "overrides": {
-    "@nativescript/core": "~9.0.0"
+    "@nativescript/core": "~9.1.0"
   },
   "gitHead": "1350d382fb4b0ed4c6e9685df909518b2688e004",
   "readme": "NativeScript Application"

--- a/packages/template-blank-react/tsconfig.json
+++ b/packages/template-blank-react/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": false,
     "module": "esnext",
     "target": "ES2020",
     "moduleResolution": "bundler",
@@ -7,12 +8,12 @@
     "emitDecoratorMetadata": true,
     "noEmitHelpers": true,
     "noEmitOnError": true,
+    "skipLibCheck": true,
     "jsx": "react",
     "lib": ["ESNext", "dom"],
-    "baseUrl": ".",
     "paths": {
-      "~/*": ["src/*"],
-      "@/*": ["src/*"]
+      "~/*": ["./src/*"],
+      "@/*": ["./src/*"]
     }
   },
   "include": ["./src/**/*.tsx?"],

--- a/packages/template-blank-solid-ts/package.json
+++ b/packages/template-blank-solid-ts/package.json
@@ -40,7 +40,7 @@
   "scripts": {},
   "dependencies": {
     "@nativescript-community/solid-js": "^0.1.2",
-    "@nativescript/core": "~9.0.0",
+    "@nativescript/core": "~9.1.0",
     "dominative": "^0.1.3",
     "solid-js": "^1.9.11",
     "solid-navigation": "1.0.0-alpha.16",

--- a/packages/template-blank-solid-ts/package.json
+++ b/packages/template-blank-solid-ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nativescript/template-blank-solid-ts",
   "main": "src/index.ts",
-  "version": "9.0.3",
+  "version": "9.1.0",
   "description": "Nativescript Starter with Solid",
   "author": "NativeScript Team <oss@nativescript.org>",
   "license": "Apache-2.0",

--- a/packages/template-blank-solid-ts/package.json
+++ b/packages/template-blank-solid-ts/package.json
@@ -60,6 +60,6 @@
     "babel-preset-solid": "^1.8.19",
     "solid-refresh": "^0.7.5",
     "tailwindcss": "~3.4.3",
-    "typescript": "~5.9.0"
+    "typescript": "~6.0.0"
   }
 }

--- a/packages/template-blank-solid-ts/tsconfig.json
+++ b/packages/template-blank-solid-ts/tsconfig.json
@@ -7,10 +7,9 @@
     "lib": ["ESNext", "DOM"],
     "jsx": "preserve",
     "jsxImportSource": "@nativescript-dom/solidjs-types",
-    "baseUrl": ".",
     "paths": {
-      "~/*": ["src/*"],
-      "@/*": ["src/*"]
+      "~/*": ["./src/*"],
+      "@/*": ["./src/*"]
     },
     "noEmit": true,
     "allowJs": true,

--- a/packages/template-blank-solid-vision/package.json
+++ b/packages/template-blank-solid-vision/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@nativescript-community/solid-js": "^0.0.6",
     "@nativescript-community/ui-collectionview": "^5.3.0",
-    "@nativescript/core": "~9.0.0",
+    "@nativescript/core": "~9.1.0",
     "dominative": "^0.1.3",
     "solid-js": "^1.7.12",
     "solid-navigation": "^1.0.0-alpha.11",

--- a/packages/template-blank-solid-vision/package.json
+++ b/packages/template-blank-solid-vision/package.json
@@ -62,6 +62,6 @@
     "patch-package": "^8.0.0",
     "solid-refresh": "^0.5.3",
     "tailwindcss": "~3.4.0",
-    "typescript": "~5.4.0"
+    "typescript": "~6.0.0"
   }
 }

--- a/packages/template-blank-solid-vision/package.json
+++ b/packages/template-blank-solid-vision/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nativescript/template-blank-solid-vision",
   "main": "src/index.js",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "Nativescript visionOS Starter with Solid",
   "author": "NativeScript Team <oss@nativescript.org>",
   "license": "Apache-2.0",

--- a/packages/template-blank-solid-vision/tsconfig.json
+++ b/packages/template-blank-solid-vision/tsconfig.json
@@ -10,10 +10,9 @@
     "jsxImportSource": "@nativescript-dom/solidjs-types",
     "noEmitHelpers": true,
     "importHelpers": true,
-    "baseUrl": ".",
     "paths": {
-      "~/*": ["src/*"],
-      "@/*": ["src/*"]
+      "~/*": ["./src/*"],
+      "@/*": ["./src/*"]
     },
     "allowJs": true,
     "types": ["node", "@nativescript-dom/core-types", "@nativescript-dom/solidjs-types"],
@@ -23,7 +22,6 @@
     "emitDecoratorMetadata": true,
     "skipLibCheck": true,
     "outDir": "dist",
-    "downlevelIteration": true,
     "maxNodeModuleJsDepth": 5
   },
   "include": ["src"],

--- a/packages/template-blank-solid/package.json
+++ b/packages/template-blank-solid/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nativescript/template-blank-solid",
   "main": "src/index.js",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "Nativescript Starter with Solid",
   "author": "NativeScript Team <oss@nativescript.org>",
   "license": "Apache-2.0",

--- a/packages/template-blank-solid/package.json
+++ b/packages/template-blank-solid/package.json
@@ -40,7 +40,7 @@
   "scripts": {},
   "dependencies": {
     "@nativescript-community/solid-js": "^0.0.6",
-    "@nativescript/core": "~9.0.0",
+    "@nativescript/core": "~9.1.0",
     "dominative": "^0.1.3",
     "solid-js": "^1.8.21",
     "solid-navigation": "1.0.0-alpha.16",

--- a/packages/template-blank-svelte-vision/package.json
+++ b/packages/template-blank-svelte-vision/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nativescript/template-blank-svelte-vision",
   "main": "src/app.ts",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "Nativescript visionOS Starter with Svelte",
   "author": "NativeScript Team <oss@nativescript.org>",
   "license": "Apache-2.0",

--- a/packages/template-blank-svelte-vision/package.json
+++ b/packages/template-blank-svelte-vision/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@nativescript-community/svelte-native": "~1.0.29",
-    "@nativescript/core": "~9.0.0"
+    "@nativescript/core": "~9.1.0"
   },
   "devDependencies": {
     "@nativescript-community/svelte-native-preprocessor": "^1.0.1",

--- a/packages/template-blank-svelte-vision/package.json
+++ b/packages/template-blank-svelte-vision/package.json
@@ -44,11 +44,12 @@
   },
   "devDependencies": {
     "@nativescript-community/svelte-native-preprocessor": "^1.0.1",
+    "@types/node": "^20.0.0",
     "@nativescript/types": "~9.0.0",
     "@nativescript/webpack": "~5.0.25",
     "svelte": "~4.2.20",
     "svelte-loader": "^3.2.4",
     "svelte-preprocess": "^6.0.3",
-    "typescript": "~5.9.2"
+    "typescript": "~6.0.0"
   }
 }

--- a/packages/template-blank-svelte-vision/tsconfig.json
+++ b/packages/template-blank-svelte-vision/tsconfig.json
@@ -8,12 +8,11 @@
     "sourceMap": true,
     "noEmitHelpers": true,
     "importHelpers": true,
-    "baseUrl": ".",
     "paths": {
-      "~/*": ["src/*"],
-      "@/*": ["src/*"]
+      "~/*": ["./src/*"],
+      "@/*": ["./src/*"]
     },
-    "typeRoots": ["types"],
+    "typeRoots": ["./types", "./node_modules/@types"],
     "types": ["node"],
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,

--- a/packages/template-blank-svelte/package.json
+++ b/packages/template-blank-svelte/package.json
@@ -3,7 +3,7 @@
   "main": "app/app.ts",
   "displayName": "Blank Svelte",
   "templateType": "App template",
-  "version": "9.0.1",
+  "version": "9.1.0",
   "description": "Blank template for NativeScript apps using Svelte",
   "author": "NativeScript Team <oss@nativescript.org>",
   "license": "Apache-2.0",

--- a/packages/template-blank-svelte/package.json
+++ b/packages/template-blank-svelte/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@nativescript-community/svelte-native": "~1.0.30",
-    "@nativescript/core": "^9.0.0"
+    "@nativescript/core": "~9.1.0"
   },
   "devDependencies": {
     "@nativescript-community/svelte-native-preprocessor": "^1.0.1",
@@ -57,7 +57,7 @@
     "typescript": "~6.0.0"
   },
   "overrides": {
-    "@nativescript/core": "^9.0.0",
+    "@nativescript/core": "~9.1.0",
     "svelte": "~4.2.20"
   }
 }

--- a/packages/template-blank-svelte/package.json
+++ b/packages/template-blank-svelte/package.json
@@ -48,12 +48,13 @@
   },
   "devDependencies": {
     "@nativescript-community/svelte-native-preprocessor": "^1.0.1",
+    "@types/node": "^20.0.0",
     "@nativescript/types": "~9.0.0",
     "@nativescript/webpack": "~5.0.28",
     "svelte": "~4.2.20",
     "svelte-loader": "^3.2.4",
     "svelte-preprocess": "^6.0.3",
-    "typescript": "~5.9.2"
+    "typescript": "~6.0.0"
   },
   "overrides": {
     "@nativescript/core": "^9.0.0",

--- a/packages/template-blank-svelte/tsconfig.json
+++ b/packages/template-blank-svelte/tsconfig.json
@@ -8,12 +8,11 @@
     "sourceMap": true,
     "noEmitHelpers": true,
     "importHelpers": true,
-    "baseUrl": ".",
     "paths": {
-      "~/*": ["app/*"],
-      "@/*": ["app/*"]
+      "~/*": ["./app/*"],
+      "@/*": ["./app/*"]
     },
-    "typeRoots": ["types"],
+    "typeRoots": ["./types", "./node_modules/@types"],
     "types": ["node"],
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,

--- a/packages/template-blank-ts/package.json
+++ b/packages/template-blank-ts/package.json
@@ -3,7 +3,7 @@
   "main": "app/app.ts",
   "displayName": "Blank",
   "templateType": "App template",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "Blank template for Vanilla NativeScript apps using TypeScript",
   "author": "NativeScript Team <oss@nativescript.org>",
   "license": "Apache-2.0",

--- a/packages/template-blank-ts/package.json
+++ b/packages/template-blank-ts/package.json
@@ -44,6 +44,6 @@
   "devDependencies": {
     "@nativescript/types": "~9.0.0",
     "@nativescript/webpack": "~5.0.25",
-    "typescript": "~5.4.0"
+    "typescript": "~6.0.0"
   }
 }

--- a/packages/template-blank-ts/package.json
+++ b/packages/template-blank-ts/package.json
@@ -38,7 +38,7 @@
     "url": "https://github.com/NativeScript/NativeScript/issues"
   },
   "dependencies": {
-    "@nativescript/core": "~9.0.0",
+    "@nativescript/core": "~9.1.0",
     "@nativescript/theme": "^3.1.0"
   },
   "devDependencies": {

--- a/packages/template-blank-ts/tsconfig.json
+++ b/packages/template-blank-ts/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": false,
     "module": "esnext",
     "target": "ES2020",
     "moduleResolution": "bundler",
@@ -9,10 +10,9 @@
     "noEmitOnError": true,
     "skipLibCheck": true,
     "lib": ["ESNext", "dom"],
-    "baseUrl": ".",
     "paths": {
-      "~/*": ["app/*"],
-      "@/*": ["app/*"]
+      "~/*": ["./app/*"],
+      "@/*": ["./app/*"]
     }
   },
   "include": ["app/**/*"],

--- a/packages/template-blank-vue-ts/package.json
+++ b/packages/template-blank-vue-ts/package.json
@@ -2,7 +2,7 @@
   "name": "@nativescript/template-blank-vue-ts",
   "main": "app/app.ts",
   "displayName": "Blank Vue Typescript",
-  "version": "9.0.9",
+  "version": "9.1.0",
   "description": "Blank Typescript template for NativeScript apps using Vue.",
   "author": "NativeScript Team <oss@nativescript.org>",
   "license": "Apache-2.0",

--- a/packages/template-blank-vue-ts/package.json
+++ b/packages/template-blank-vue-ts/package.json
@@ -50,6 +50,6 @@
     "@nativescript/webpack": "~5.0.31",
     "@types/node": "^20.0.0",
     "tailwindcss": "^4.0.0",
-    "typescript": "~5.4.0"
+    "typescript": "~6.0.0"
   }
 }

--- a/packages/template-blank-vue-ts/package.json
+++ b/packages/template-blank-vue-ts/package.json
@@ -41,7 +41,7 @@
     "category-general"
   ],
   "dependencies": {
-    "@nativescript/core": "~9.0.0",
+    "@nativescript/core": "~9.1.0",
     "nativescript-vue": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/template-blank-vue-ts/tsconfig.json
+++ b/packages/template-blank-vue-ts/tsconfig.json
@@ -8,12 +8,11 @@
     "sourceMap": true,
     "noEmitHelpers": true,
     "importHelpers": true,
-    "baseUrl": ".",
     "paths": {
-      "~/*": ["app/*"],
-      "@/*": ["app/*"]
+      "~/*": ["./app/*"],
+      "@/*": ["./app/*"]
     },
-    "typeRoots": ["types"],
+    "typeRoots": ["./types", "./node_modules/@types"],
     "types": ["node"],
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,

--- a/packages/template-blank-vue-vision/package.json
+++ b/packages/template-blank-vue-vision/package.json
@@ -2,7 +2,7 @@
   "name": "@nativescript/template-blank-vue-vision",
   "main": "src/app.ts",
   "displayName": "Blank Vue Typescript",
-  "version": "9.0.1",
+  "version": "9.1.0",
   "description": "Nativescript visionOS Starter with Vue",
   "author": "NativeScript Team <oss@nativescript.org>",
   "license": "Apache-2.0",

--- a/packages/template-blank-vue-vision/package.json
+++ b/packages/template-blank-vue-vision/package.json
@@ -38,7 +38,7 @@
     "Vision Pro"
   ],
   "dependencies": {
-    "@nativescript/core": "~9.0.0",
+    "@nativescript/core": "~9.1.0",
     "nativescript-vue": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/template-blank-vue-vision/package.json
+++ b/packages/template-blank-vue-vision/package.json
@@ -47,6 +47,6 @@
     "@nativescript/webpack": "~5.0.25",
     "@types/node": "~17.0.21",
     "tailwindcss": "~3.4.0",
-    "typescript": "~5.4.0"
+    "typescript": "~6.0.0"
   }
 }

--- a/packages/template-blank-vue-vision/tsconfig.json
+++ b/packages/template-blank-vue-vision/tsconfig.json
@@ -8,10 +8,9 @@
     "sourceMap": true,
     "noEmitHelpers": true,
     "importHelpers": true,
-    "baseUrl": ".",
     "paths": {
-      "~/*": ["src/*"],
-      "@/*": ["src/*"]
+      "~/*": ["./src/*"],
+      "@/*": ["./src/*"]
     },
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,

--- a/packages/template-blank-vue/package.json
+++ b/packages/template-blank-vue/package.json
@@ -2,7 +2,7 @@
   "name": "@nativescript/template-blank-vue",
   "main": "app/app.ts",
   "displayName": "Blank",
-  "version": "9.0.9",
+  "version": "9.1.0",
   "description": "Blank template for NativeScript apps using Vue.",
   "author": "NativeScript Team <oss@nativescript.org>",
   "license": "Apache-2.0",

--- a/packages/template-blank-vue/package.json
+++ b/packages/template-blank-vue/package.json
@@ -41,7 +41,7 @@
     "category-general"
   ],
   "dependencies": {
-    "@nativescript/core": "~9.0.0",
+    "@nativescript/core": "~9.1.0",
     "nativescript-vue": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/template-blank-vue/package.json
+++ b/packages/template-blank-vue/package.json
@@ -50,6 +50,6 @@
     "@nativescript/webpack": "~5.0.31",
     "@types/node": "^20.0.0",
     "tailwindcss": "^4.0.0",
-    "typescript": "~5.8.0"
+    "typescript": "~6.0.0"
   }
 }

--- a/packages/template-blank-vue/tsconfig.json
+++ b/packages/template-blank-vue/tsconfig.json
@@ -8,12 +8,11 @@
     "sourceMap": true,
     "noEmitHelpers": true,
     "importHelpers": true,
-    "baseUrl": ".",
     "paths": {
-      "~/*": ["app/*"],
-      "@/*": ["app/*"]
+      "~/*": ["./app/*"],
+      "@/*": ["./app/*"]
     },
-    "typeRoots": ["types"],
+    "typeRoots": ["./types", "./node_modules/@types"],
     "types": ["node"],
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,

--- a/packages/template-blank/package.json
+++ b/packages/template-blank/package.json
@@ -3,7 +3,7 @@
   "main": "app/app.js",
   "displayName": "Blank",
   "templateType": "App template",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "Blank template for Vanilla NativeScript apps using JavaScript",
   "author": "NativeScript Team <oss@nativescript.org>",
   "license": "Apache-2.0",

--- a/packages/template-blank/package.json
+++ b/packages/template-blank/package.json
@@ -38,7 +38,7 @@
     "url": "https://github.com/NativeScript/NativeScript/issues"
   },
   "dependencies": {
-    "@nativescript/core": "~9.0.0",
+    "@nativescript/core": "~9.1.0",
     "@nativescript/theme": "^3.1.0"
   },
   "devDependencies": {

--- a/packages/template-drawer-navigation-ng/package.json
+++ b/packages/template-drawer-navigation-ng/package.json
@@ -3,7 +3,7 @@
   "main": "src/main.ts",
   "displayName": "Navigation Drawer",
   "templateType": "App template",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "Side navigation template",
   "author": "NativeScript Team <oss@nativescript.org>",
   "license": "Apache-2.0",

--- a/packages/template-drawer-navigation-ng/package.json
+++ b/packages/template-drawer-navigation-ng/package.json
@@ -49,12 +49,12 @@
     "@angular/platform-browser": "~22.0.0",
     "@angular/platform-browser-dynamic": "~22.0.0",
     "@angular/router": "~22.0.0",
-    "@nativescript/angular": "^21.0.0",
-    "@nativescript/core": "~9.0.0",
+    "@nativescript/angular": "~22.0.0",
+    "@nativescript/core": "~9.1.0",
     "@nativescript/theme": "^3.1.0",
     "nativescript-ui-sidedrawer": "~15.2.0",
     "rxjs": "~7.8.0",
-    "zone.js": "~0.15.0"
+    "zone.js": "~0.16.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~22.0.0",

--- a/packages/template-drawer-navigation-ng/package.json
+++ b/packages/template-drawer-navigation-ng/package.json
@@ -41,27 +41,27 @@
     "url": "https://github.com/NativeScript/NativeScript/issues"
   },
   "dependencies": {
-    "@angular/animations": "~18.0.0",
-    "@angular/common": "~18.0.0",
-    "@angular/compiler": "~18.0.0",
-    "@angular/core": "~18.0.0",
-    "@angular/forms": "~18.0.0",
-    "@angular/platform-browser": "~18.0.0",
-    "@angular/platform-browser-dynamic": "~18.0.0",
-    "@angular/router": "~18.0.0",
-    "@nativescript/angular": "^18.0.0",
+    "@angular/animations": "~22.0.0",
+    "@angular/common": "~22.0.0",
+    "@angular/compiler": "~22.0.0",
+    "@angular/core": "~22.0.0",
+    "@angular/forms": "~22.0.0",
+    "@angular/platform-browser": "~22.0.0",
+    "@angular/platform-browser-dynamic": "~22.0.0",
+    "@angular/router": "~22.0.0",
+    "@nativescript/angular": "^21.0.0",
     "@nativescript/core": "~9.0.0",
     "@nativescript/theme": "^3.1.0",
     "nativescript-ui-sidedrawer": "~15.2.0",
     "rxjs": "~7.8.0",
-    "zone.js": "~0.14.0"
+    "zone.js": "~0.15.0"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "~18.0.0",
-    "@angular/compiler-cli": "~18.0.0",
+    "@angular-devkit/build-angular": "~22.0.0",
+    "@angular/compiler-cli": "~22.0.0",
     "@nativescript/types": "~9.0.0",
     "@nativescript/webpack": "~5.0.25",
-    "@ngtools/webpack": "~18.0.0",
-    "typescript": "~5.4.0"
+    "@ngtools/webpack": "~22.0.0",
+    "typescript": "~6.0.0"
   }
 }

--- a/packages/template-drawer-navigation-ng/tsconfig.json
+++ b/packages/template-drawer-navigation-ng/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": false,
     "module": "esnext",
     "target": "ES2020",
     "moduleResolution": "bundler",
@@ -9,10 +10,9 @@
     "noEmitOnError": true,
     "skipLibCheck": true,
     "lib": ["ESNext", "dom"],
-    "baseUrl": ".",
     "paths": {
-      "~/*": ["src/*"],
-      "@/*": ["src/*"]
+      "~/*": ["./src/*"],
+      "@/*": ["./src/*"]
     }
   },
   "include": ["./src/**/*.ios.ts", "./src/**/*.android.ts"],

--- a/packages/template-drawer-navigation-ts/package.json
+++ b/packages/template-drawer-navigation-ts/package.json
@@ -3,7 +3,7 @@
   "main": "src/main.ts",
   "displayName": "Navigation Drawer",
   "templateType": "App template",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "Side navigation template",
   "author": "NativeScript Team <oss@nativescript.org>",
   "license": "Apache-2.0",

--- a/packages/template-drawer-navigation-ts/package.json
+++ b/packages/template-drawer-navigation-ts/package.json
@@ -40,7 +40,7 @@
     "url": "https://github.com/NativeScript/NativeScript/issues"
   },
   "dependencies": {
-    "@nativescript/core": "~9.0.0",
+    "@nativescript/core": "~9.1.0",
     "@nativescript/theme": "^3.1.0",
     "nativescript-ui-sidedrawer": "~15.2.0",
     "rxjs": "~7.8.0"

--- a/packages/template-drawer-navigation-ts/package.json
+++ b/packages/template-drawer-navigation-ts/package.json
@@ -48,6 +48,6 @@
   "devDependencies": {
     "@nativescript/types": "~9.0.0",
     "@nativescript/webpack": "~5.0.25",
-    "typescript": "~5.4.0"
+    "typescript": "~6.0.0"
   }
 }

--- a/packages/template-drawer-navigation-ts/tsconfig.json
+++ b/packages/template-drawer-navigation-ts/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": false,
     "module": "esnext",
     "target": "ES2020",
     "moduleResolution": "bundler",
@@ -9,10 +10,9 @@
     "noEmitOnError": true,
     "skipLibCheck": true,
     "lib": ["ESNext", "dom"],
-    "baseUrl": ".",
     "paths": {
-      "~/*": ["app/*"],
-      "@/*": ["app/*"]
+      "~/*": ["./app/*"],
+      "@/*": ["./app/*"]
     }
   },
   "include": ["src/**/*"],

--- a/packages/template-drawer-navigation-vue/package.json
+++ b/packages/template-drawer-navigation-vue/package.json
@@ -52,6 +52,6 @@
     "@nativescript/webpack": "~5.0.31",
     "@types/node": "^20.0.0",
     "tailwindcss": "^4.0.0",
-    "typescript": "~5.8.0"
+    "typescript": "~6.0.0"
   }
 }

--- a/packages/template-drawer-navigation-vue/package.json
+++ b/packages/template-drawer-navigation-vue/package.json
@@ -3,7 +3,7 @@
   "main": "app/app.ts",
   "displayName": "Navigation Drawer",
   "templateType": "App template",
-  "version": "9.0.6",
+  "version": "9.1.0",
   "description": "Side navigation template using Vue.",
   "author": "NativeScript Team <oss@nativescript.org>",
   "license": "Apache-2.0",

--- a/packages/template-drawer-navigation-vue/package.json
+++ b/packages/template-drawer-navigation-vue/package.json
@@ -42,7 +42,7 @@
     "url": "https://github.com/NativeScript/NativeScript/issues"
   },
   "dependencies": {
-    "@nativescript/core": "~9.0.0",
+    "@nativescript/core": "~9.1.0",
     "@nativescript-community/ui-drawer": "^0.1.31",
     "nativescript-vue": "^3.0.0"
   },

--- a/packages/template-drawer-navigation-vue/tsconfig.json
+++ b/packages/template-drawer-navigation-vue/tsconfig.json
@@ -8,12 +8,11 @@
     "sourceMap": true,
     "noEmitHelpers": true,
     "importHelpers": true,
-    "baseUrl": ".",
     "paths": {
-      "~/*": ["app/*"],
-      "@/*": ["app/*"]
+      "~/*": ["./app/*"],
+      "@/*": ["./app/*"]
     },
-    "typeRoots": ["types"],
+    "typeRoots": ["./types", "./node_modules/@types"],
     "types": ["node"],
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,

--- a/packages/template-drawer-navigation/package.json
+++ b/packages/template-drawer-navigation/package.json
@@ -3,7 +3,7 @@
   "main": "app/app.js",
   "displayName": "Navigation Drawer",
   "templateType": "App template",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "Side navigation template",
   "author": "NativeScript Team <oss@nativescript.org>",
   "license": "Apache-2.0",

--- a/packages/template-drawer-navigation/package.json
+++ b/packages/template-drawer-navigation/package.json
@@ -39,7 +39,7 @@
     "url": "https://github.com/NativeScript/NativeScript/issues"
   },
   "dependencies": {
-    "@nativescript/core": "~9.0.0",
+    "@nativescript/core": "~9.1.0",
     "@nativescript/theme": "^3.1.0",
     "nativescript-ui-sidedrawer": "~15.2.0",
     "rxjs": "~7.8.0"

--- a/packages/template-hello-world-ng-vision/package.json
+++ b/packages/template-hello-world-ng-vision/package.json
@@ -35,27 +35,27 @@
     "url": "https://github.com/NativeScript/NativeScript/issues"
   },
   "dependencies": {
-    "@angular/animations": "~18.0.0",
-    "@angular/common": "~18.0.0",
-    "@angular/compiler": "~18.0.0",
-    "@angular/core": "~18.0.0",
-    "@angular/forms": "~18.0.0",
-    "@angular/platform-browser": "~18.0.0",
-    "@angular/platform-browser-dynamic": "~18.0.0",
-    "@angular/router": "~18.0.0",
-    "@nativescript/angular": "^18.0.0",
+    "@angular/animations": "~22.0.0",
+    "@angular/common": "~22.0.0",
+    "@angular/compiler": "~22.0.0",
+    "@angular/core": "~22.0.0",
+    "@angular/forms": "~22.0.0",
+    "@angular/platform-browser": "~22.0.0",
+    "@angular/platform-browser-dynamic": "~22.0.0",
+    "@angular/router": "~22.0.0",
+    "@nativescript/angular": "^21.0.0",
     "@nativescript/core": "~9.0.0",
     "rxjs": "~7.8.0",
-    "zone.js": "~0.14.0"
+    "zone.js": "~0.15.0"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "~18.0.0",
-    "@angular/compiler-cli": "~18.0.0",
+    "@angular-devkit/build-angular": "~22.0.0",
+    "@angular/compiler-cli": "~22.0.0",
     "@nativescript/tailwind": "^2.1.0",
     "@nativescript/types": "~9.0.0",
     "@nativescript/webpack": "~5.0.25",
-    "@ngtools/webpack": "~18.0.0",
+    "@ngtools/webpack": "~22.0.0",
     "tailwindcss": "~3.4.0",
-    "typescript": "~5.4.0"
+    "typescript": "~6.0.0"
   }
 }

--- a/packages/template-hello-world-ng-vision/package.json
+++ b/packages/template-hello-world-ng-vision/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nativescript/template-hello-world-ng-vision",
   "main": "./src/main.ts",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "author": "NativeScript Team <oss@nativescript.org>",
   "description": "Nativescript visionOS Starter with Angular",
   "license": "Apache-2.0",

--- a/packages/template-hello-world-ng-vision/package.json
+++ b/packages/template-hello-world-ng-vision/package.json
@@ -43,10 +43,10 @@
     "@angular/platform-browser": "~22.0.0",
     "@angular/platform-browser-dynamic": "~22.0.0",
     "@angular/router": "~22.0.0",
-    "@nativescript/angular": "^21.0.0",
-    "@nativescript/core": "~9.0.0",
+    "@nativescript/angular": "~22.0.0",
+    "@nativescript/core": "~9.1.0",
     "rxjs": "~7.8.0",
-    "zone.js": "~0.15.0"
+    "zone.js": "~0.16.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~22.0.0",

--- a/packages/template-hello-world-ng-vision/tsconfig.json
+++ b/packages/template-hello-world-ng-vision/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": false,
     "module": "esnext",
     "target": "ES2020",
     "moduleResolution": "bundler",
@@ -9,10 +10,9 @@
     "noEmitOnError": true,
     "skipLibCheck": true,
     "lib": ["ESNext", "dom"],
-    "baseUrl": ".",
     "paths": {
-      "~/*": ["src/*"],
-      "@/*": ["src/*"]
+      "~/*": ["./src/*"],
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src/tests/**/*.ts", "src/**/*.ios.ts", "src/**/*.android.ts"],

--- a/packages/template-hello-world-ng/package.json
+++ b/packages/template-hello-world-ng/package.json
@@ -34,27 +34,27 @@
     "url": "https://github.com/NativeScript/NativeScript/issues"
   },
   "dependencies": {
-    "@angular/animations": "~20.2.0",
-    "@angular/common": "~20.2.0",
-    "@angular/compiler": "~20.2.0",
-    "@angular/core": "~20.2.0",
-    "@angular/forms": "~20.2.0",
-    "@angular/platform-browser": "~20.2.0",
-    "@angular/platform-browser-dynamic": "~20.2.0",
-    "@angular/router": "~20.2.0",
-    "@nativescript/angular": "^20.0.0",
+    "@angular/animations": "~22.0.0",
+    "@angular/common": "~22.0.0",
+    "@angular/compiler": "~22.0.0",
+    "@angular/core": "~22.0.0",
+    "@angular/forms": "~22.0.0",
+    "@angular/platform-browser": "~22.0.0",
+    "@angular/platform-browser-dynamic": "~22.0.0",
+    "@angular/router": "~22.0.0",
+    "@nativescript/angular": "^21.0.0",
     "@nativescript/core": "~9.0.0",
     "rxjs": "~7.8.0",
     "zone.js": "~0.15.0"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "~20.2.0",
-    "@angular/compiler-cli": "~20.2.0",
+    "@angular-devkit/build-angular": "~22.0.0",
+    "@angular/compiler-cli": "~22.0.0",
     "@nativescript/tailwind": "^2.1.0",
     "@nativescript/types": "~9.0.0",
     "@nativescript/webpack": "~5.0.25",
-    "@ngtools/webpack": "~20.2.0",
+    "@ngtools/webpack": "~22.0.0",
     "tailwindcss": "~3.4.0",
-    "typescript": "~5.8.0"
+    "typescript": "~6.0.0"
   }
 }

--- a/packages/template-hello-world-ng/package.json
+++ b/packages/template-hello-world-ng/package.json
@@ -42,10 +42,10 @@
     "@angular/platform-browser": "~22.0.0",
     "@angular/platform-browser-dynamic": "~22.0.0",
     "@angular/router": "~22.0.0",
-    "@nativescript/angular": "^21.0.0",
-    "@nativescript/core": "~9.0.0",
+    "@nativescript/angular": "~22.0.0",
+    "@nativescript/core": "~9.1.0",
     "rxjs": "~7.8.0",
-    "zone.js": "~0.15.0"
+    "zone.js": "~0.16.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~22.0.0",

--- a/packages/template-hello-world-ng/package.json
+++ b/packages/template-hello-world-ng/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nativescript/template-hello-world-ng",
   "main": "./src/main.ts",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "author": "NativeScript Team <oss@nativescript.org>",
   "description": "NativeScript Angular Hello World template",
   "license": "Apache-2.0",

--- a/packages/template-hello-world-ng/tsconfig.json
+++ b/packages/template-hello-world-ng/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": false,
     "module": "esnext",
     "target": "ES2020",
     "moduleResolution": "bundler",
@@ -9,10 +10,9 @@
     "noEmitOnError": true,
     "skipLibCheck": true,
     "lib": ["ESNext", "dom"],
-    "baseUrl": ".",
     "paths": {
-      "~/*": ["src/*"],
-      "@/*": ["src/*"]
+      "~/*": ["./src/*"],
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src/tests/**/*.ts", "src/**/*.ios.ts", "src/**/*.android.ts"],

--- a/packages/template-hello-world-ts-vision/package.json
+++ b/packages/template-hello-world-ts-vision/package.json
@@ -43,6 +43,6 @@
     "@nativescript/types": "~9.0.0",
     "@nativescript/webpack": "~5.0.25",
     "tailwindcss": "~3.4.0",
-    "typescript": "~5.4.0"
+    "typescript": "~6.0.0"
   }
 }

--- a/packages/template-hello-world-ts-vision/package.json
+++ b/packages/template-hello-world-ts-vision/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nativescript/template-hello-world-ts-vision",
   "main": "src/app.ts",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "author": "NativeScript Team <oss@nativescript.org>",
   "description": "NativeScript visionOS Starter with TypeScript",
   "license": "Apache-2.0",

--- a/packages/template-hello-world-ts-vision/package.json
+++ b/packages/template-hello-world-ts-vision/package.json
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/NativeScript/nativescript-app-templates",
   "dependencies": {
-    "@nativescript/core": "~9.0.0"
+    "@nativescript/core": "~9.1.0"
   },
   "devDependencies": {
     "@nativescript/tailwind": "^2.1.0",

--- a/packages/template-hello-world-ts-vision/tsconfig.json
+++ b/packages/template-hello-world-ts-vision/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": false,
     "module": "esnext",
     "target": "ES2020",
     "moduleResolution": "bundler",
@@ -9,10 +10,9 @@
     "noEmitOnError": true,
     "skipLibCheck": true,
     "lib": ["ESNext", "dom"],
-    "baseUrl": ".",
     "paths": {
-      "~/*": ["src/*"],
-      "@/*": ["src/*"]
+      "~/*": ["./src/*"],
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src/**/*"],

--- a/packages/template-hello-world-ts/package.json
+++ b/packages/template-hello-world-ts/package.json
@@ -39,6 +39,6 @@
   "devDependencies": {
     "@nativescript/types": "~9.0.0",
     "@nativescript/webpack": "~5.0.25",
-    "typescript": "~5.4.0"
+    "typescript": "~6.0.0"
   }
 }

--- a/packages/template-hello-world-ts/package.json
+++ b/packages/template-hello-world-ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nativescript/template-hello-world-ts",
   "main": "app/app.ts",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "author": "NativeScript Team <oss@nativescript.org>",
   "description": "Nativescript hello-world-ts project template",
   "license": "Apache-2.0",

--- a/packages/template-hello-world-ts/package.json
+++ b/packages/template-hello-world-ts/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/NativeScript/nativescript-app-templates",
   "dependencies": {
-    "@nativescript/core": "~9.0.0",
+    "@nativescript/core": "~9.1.0",
     "@nativescript/theme": "^3.1.0"
   },
   "devDependencies": {

--- a/packages/template-hello-world-ts/tsconfig.json
+++ b/packages/template-hello-world-ts/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": false,
     "module": "esnext",
     "target": "ES2020",
     "moduleResolution": "bundler",
@@ -9,10 +10,9 @@
     "noEmitOnError": true,
     "skipLibCheck": true,
     "lib": ["ESNext", "dom"],
-    "baseUrl": ".",
     "paths": {
-      "~/*": ["app/*"],
-      "@/*": ["app/*"]
+      "~/*": ["./app/*"],
+      "@/*": ["./app/*"]
     }
   },
   "include": ["app/**/*"],

--- a/packages/template-hello-world/package.json
+++ b/packages/template-hello-world/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/NativeScript/nativescript-app-templates",
   "dependencies": {
-    "@nativescript/core": "~9.0.0",
+    "@nativescript/core": "~9.1.0",
     "@nativescript/theme": "^3.1.0"
   },
   "devDependencies": {

--- a/packages/template-hello-world/package.json
+++ b/packages/template-hello-world/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nativescript/template-hello-world",
   "main": "app/app.js",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "author": "NativeScript Team <oss@nativescript.org>",
   "description": "Nativescript hello-world project template",
   "license": "Apache-2.0",

--- a/packages/template-master-detail-ng/package.json
+++ b/packages/template-master-detail-ng/package.json
@@ -49,13 +49,13 @@
     "@angular/platform-browser": "~22.0.0",
     "@angular/platform-browser-dynamic": "~22.0.0",
     "@angular/router": "~22.0.0",
-    "@nativescript/angular": "^21.0.0",
-    "@nativescript/core": "~9.0.0",
+    "@nativescript/angular": "~22.0.0",
+    "@nativescript/core": "~9.1.0",
     "@nativescript/imagepicker": "~3.1.0",
     "@nativescript/theme": "^3.1.0",
     "nativescript-ui-listview": "~15.2.0",
     "rxjs": "~7.8.0",
-    "zone.js": "~0.15.0"
+    "zone.js": "~0.16.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~22.0.0",

--- a/packages/template-master-detail-ng/package.json
+++ b/packages/template-master-detail-ng/package.json
@@ -41,28 +41,28 @@
     "url": "https://github.com/NativeScript/NativeScript/issues"
   },
   "dependencies": {
-    "@angular/animations": "~18.0.0",
-    "@angular/common": "~18.0.0",
-    "@angular/compiler": "~18.0.0",
-    "@angular/core": "~18.0.0",
-    "@angular/forms": "~18.0.0",
-    "@angular/platform-browser": "~18.0.0",
-    "@angular/platform-browser-dynamic": "~18.0.0",
-    "@angular/router": "~18.0.0",
-    "@nativescript/angular": "^18.0.0",
+    "@angular/animations": "~22.0.0",
+    "@angular/common": "~22.0.0",
+    "@angular/compiler": "~22.0.0",
+    "@angular/core": "~22.0.0",
+    "@angular/forms": "~22.0.0",
+    "@angular/platform-browser": "~22.0.0",
+    "@angular/platform-browser-dynamic": "~22.0.0",
+    "@angular/router": "~22.0.0",
+    "@nativescript/angular": "^21.0.0",
     "@nativescript/core": "~9.0.0",
     "@nativescript/imagepicker": "~3.1.0",
     "@nativescript/theme": "^3.1.0",
     "nativescript-ui-listview": "~15.2.0",
     "rxjs": "~7.8.0",
-    "zone.js": "~0.14.0"
+    "zone.js": "~0.15.0"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "~18.0.0",
-    "@angular/compiler-cli": "~18.0.0",
+    "@angular-devkit/build-angular": "~22.0.0",
+    "@angular/compiler-cli": "~22.0.0",
     "@nativescript/types": "~9.0.0",
     "@nativescript/webpack": "~5.0.25",
-    "@ngtools/webpack": "~18.0.0",
-    "typescript": "~5.4.0"
+    "@ngtools/webpack": "~22.0.0",
+    "typescript": "~6.0.0"
   }
 }

--- a/packages/template-master-detail-ng/package.json
+++ b/packages/template-master-detail-ng/package.json
@@ -3,7 +3,7 @@
   "main": "src/main.ts",
   "displayName": "Master-Detail with Firebase",
   "templateType": "App template",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "Master-detail interface to display collection of items from json collection and inspect and edit selected item properties. ",
   "author": "NativeScript Team <oss@nativescript.org>",
   "license": "Apache-2.0",

--- a/packages/template-master-detail-ng/tsconfig.json
+++ b/packages/template-master-detail-ng/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": false,
     "module": "esnext",
     "target": "ES2020",
     "moduleResolution": "bundler",
@@ -9,10 +10,9 @@
     "noEmitOnError": true,
     "skipLibCheck": true,
     "lib": ["ESNext", "dom"],
-    "baseUrl": ".",
     "paths": {
-      "~/*": ["src/*"],
-      "@/*": ["src/*"]
+      "~/*": ["./src/*"],
+      "@/*": ["./src/*"]
     }
   },
   "include": ["./src/**/*.android.ts", "./src/**/*.ios.ts"],

--- a/packages/template-master-detail-ts/package.json
+++ b/packages/template-master-detail-ts/package.json
@@ -39,7 +39,7 @@
     "url": "https://github.com/NativeScript/NativeScript/issues"
   },
   "dependencies": {
-    "@nativescript/core": "~9.0.0",
+    "@nativescript/core": "~9.1.0",
     "@nativescript/imagepicker": "~3.1.0",
     "@nativescript/theme": "^3.1.0",
     "nativescript-ui-listview": "~15.2.0",

--- a/packages/template-master-detail-ts/package.json
+++ b/packages/template-master-detail-ts/package.json
@@ -3,7 +3,7 @@
   "main": "app/app.ts",
   "displayName": "Master-Detail",
   "templateType": "App template",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "Master-detail interface to display collection of items from json collection and inspect and edit selected item properties.",
   "author": "NativeScript Team <oss@nativescript.org>",
   "license": "Apache-2.0",

--- a/packages/template-master-detail-ts/package.json
+++ b/packages/template-master-detail-ts/package.json
@@ -48,6 +48,6 @@
   "devDependencies": {
     "@nativescript/types": "~9.0.0",
     "@nativescript/webpack": "~5.0.25",
-    "typescript": "~5.4.0"
+    "typescript": "~6.0.0"
   }
 }

--- a/packages/template-master-detail-ts/tsconfig.json
+++ b/packages/template-master-detail-ts/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": false,
     "module": "esnext",
     "target": "es2020",
     "moduleResolution": "bundler",
@@ -9,10 +10,9 @@
     "noEmitOnError": true,
     "skipLibCheck": true,
     "lib": ["ESNext", "dom"],
-    "baseUrl": ".",
     "paths": {
-      "~/*": ["app/*"],
-      "@/*": ["app/*"]
+      "~/*": ["./app/*"],
+      "@/*": ["./app/*"]
     }
   },
   "include": ["app/**/*"],

--- a/packages/template-master-detail-vue/package.json
+++ b/packages/template-master-detail-vue/package.json
@@ -2,7 +2,7 @@
   "name": "@nativescript/template-master-detail-vue",
   "main": "app/app.js",
   "displayName": "Master Detail",
-  "version": "9.0.1",
+  "version": "9.1.0",
   "description": "Master-detail interface to display collection of items from json collection and inspect and edit selected item properties.",
   "author": "NativeScript Team <oss@nativescript.org>",
   "license": "Apache-2.0",

--- a/packages/template-master-detail-vue/package.json
+++ b/packages/template-master-detail-vue/package.json
@@ -40,7 +40,7 @@
     "category-general"
   ],
   "dependencies": {
-    "@nativescript/core": "~9.0.0",
+    "@nativescript/core": "~9.1.0",
     "@nativescript/imagepicker": "~3.1.0",
     "@nativescript/theme": "^3.1.0",
     "nativescript-ui-listview": "~15.2.0",

--- a/packages/template-master-detail/package.json
+++ b/packages/template-master-detail/package.json
@@ -39,7 +39,7 @@
     "url": "https://github.com/NativeScript/NativeScript/issues"
   },
   "dependencies": {
-    "@nativescript/core": "~9.0.0",
+    "@nativescript/core": "~9.1.0",
     "@nativescript/imagepicker": "~3.1.0",
     "@nativescript/theme": "^3.1.0",
     "nativescript-ui-listview": "~15.2.0",

--- a/packages/template-master-detail/package.json
+++ b/packages/template-master-detail/package.json
@@ -3,7 +3,7 @@
   "main": "app/app.js",
   "displayName": "Master-Detail",
   "templateType": "App template",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "Master-detail interface to display collection of items from json collection and inspect and edit selected item properties.",
   "author": "NativeScript Team <oss@nativescript.org>",
   "license": "Apache-2.0",

--- a/packages/template-tab-navigation-ng/package.json
+++ b/packages/template-tab-navigation-ng/package.json
@@ -49,11 +49,11 @@
     "@angular/platform-browser": "~22.0.0",
     "@angular/platform-browser-dynamic": "~22.0.0",
     "@angular/router": "~22.0.0",
-    "@nativescript/angular": "^21.0.0",
-    "@nativescript/core": "~9.0.0",
+    "@nativescript/angular": "~22.0.0",
+    "@nativescript/core": "~9.1.0",
     "@nativescript/theme": "^3.1.0",
     "rxjs": "~7.8.0",
-    "zone.js": "~0.15.0"
+    "zone.js": "~0.16.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~22.0.0",

--- a/packages/template-tab-navigation-ng/package.json
+++ b/packages/template-tab-navigation-ng/package.json
@@ -41,26 +41,26 @@
     "url": "https://github.com/NativeScript/NativeScript/issues"
   },
   "dependencies": {
-    "@angular/animations": "~18.0.0",
-    "@angular/common": "~18.0.0",
-    "@angular/compiler": "~18.0.0",
-    "@angular/core": "~18.0.0",
-    "@angular/forms": "~18.0.0",
-    "@angular/platform-browser": "~18.0.0",
-    "@angular/platform-browser-dynamic": "~18.0.0",
-    "@angular/router": "~18.0.0",
-    "@nativescript/angular": "^18.0.0",
+    "@angular/animations": "~22.0.0",
+    "@angular/common": "~22.0.0",
+    "@angular/compiler": "~22.0.0",
+    "@angular/core": "~22.0.0",
+    "@angular/forms": "~22.0.0",
+    "@angular/platform-browser": "~22.0.0",
+    "@angular/platform-browser-dynamic": "~22.0.0",
+    "@angular/router": "~22.0.0",
+    "@nativescript/angular": "^21.0.0",
     "@nativescript/core": "~9.0.0",
     "@nativescript/theme": "^3.1.0",
     "rxjs": "~7.8.0",
-    "zone.js": "~0.14.0"
+    "zone.js": "~0.15.0"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "~18.0.0",
-    "@angular/compiler-cli": "~18.0.0",
+    "@angular-devkit/build-angular": "~22.0.0",
+    "@angular/compiler-cli": "~22.0.0",
     "@nativescript/types": "~9.0.0",
     "@nativescript/webpack": "~5.0.25",
-    "@ngtools/webpack": "~18.0.0",
-    "typescript": "~5.4.0"
+    "@ngtools/webpack": "~22.0.0",
+    "typescript": "~6.0.0"
   }
 }

--- a/packages/template-tab-navigation-ng/package.json
+++ b/packages/template-tab-navigation-ng/package.json
@@ -3,7 +3,7 @@
   "main": "src/main.ts",
   "displayName": "Tabs",
   "templateType": "App template",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "Tabbed interface template",
   "author": "NativeScript Team <oss@nativescript.org>",
   "license": "Apache-2.0",

--- a/packages/template-tab-navigation-ng/tsconfig.json
+++ b/packages/template-tab-navigation-ng/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": false,
     "module": "esnext",
     "target": "ES2020",
     "moduleResolution": "bundler",
@@ -9,10 +10,9 @@
     "noEmitOnError": true,
     "skipLibCheck": true,
     "lib": ["ESNext", "dom"],
-    "baseUrl": ".",
     "paths": {
-      "~/*": ["src/*"],
-      "@/*": ["src/*"]
+      "~/*": ["./src/*"],
+      "@/*": ["./src/*"]
     }
   },
   "include": ["./src/**/*.ios.ts", "./src/**/*.android.ts"],

--- a/packages/template-tab-navigation-ts/package.json
+++ b/packages/template-tab-navigation-ts/package.json
@@ -40,7 +40,7 @@
     "url": "https://github.com/NativeScript/NativeScript/issues"
   },
   "dependencies": {
-    "@nativescript/core": "~9.0.0",
+    "@nativescript/core": "~9.1.0",
     "@nativescript/theme": "^3.1.0"
   },
   "devDependencies": {

--- a/packages/template-tab-navigation-ts/package.json
+++ b/packages/template-tab-navigation-ts/package.json
@@ -3,7 +3,7 @@
   "main": "app/app.ts",
   "displayName": "Tabs",
   "templateType": "App template",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "Tabbed interface template",
   "author": "NativeScript Team <oss@nativescript.org>",
   "license": "Apache-2.0",

--- a/packages/template-tab-navigation-ts/package.json
+++ b/packages/template-tab-navigation-ts/package.json
@@ -46,6 +46,6 @@
   "devDependencies": {
     "@nativescript/types": "~9.0.0",
     "@nativescript/webpack": "~5.0.25",
-    "typescript": "~5.8.0"
+    "typescript": "~6.0.0"
   }
 }

--- a/packages/template-tab-navigation-ts/tsconfig.json
+++ b/packages/template-tab-navigation-ts/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": false,
     "module": "esnext",
     "target": "ES2020",
     "moduleResolution": "bundler",
@@ -9,10 +10,9 @@
     "noEmitOnError": true,
     "skipLibCheck": true,
     "lib": ["ESNext", "dom"],
-    "baseUrl": ".",
     "paths": {
-      "~/*": ["app/*"],
-      "@/*": ["app/*"]
+      "~/*": ["./app/*"],
+      "@/*": ["./app/*"]
     }
   },
   "include": ["app/**/*"],

--- a/packages/template-tab-navigation-vue/package.json
+++ b/packages/template-tab-navigation-vue/package.json
@@ -41,7 +41,7 @@
     "category-general"
   ],
   "dependencies": {
-    "@nativescript/core": "~9.0.0",
+    "@nativescript/core": "~9.1.0",
     "nativescript-vue": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/template-tab-navigation-vue/package.json
+++ b/packages/template-tab-navigation-vue/package.json
@@ -50,6 +50,6 @@
     "@nativescript/webpack": "~5.0.31",
     "@types/node": "^20.0.0",
     "tailwindcss": "^4.0.0",
-    "typescript": "~5.8.0"
+    "typescript": "~6.0.0"
   }
 }

--- a/packages/template-tab-navigation-vue/package.json
+++ b/packages/template-tab-navigation-vue/package.json
@@ -2,7 +2,7 @@
   "name": "@nativescript/template-tab-navigation-vue",
   "main": "app/app.ts",
   "displayName": "Tabs",
-  "version": "9.0.4",
+  "version": "9.1.0",
   "description": "Tabbed interface template using Vue",
   "author": "NativeScript Team <oss@nativescript.org>",
   "license": "Apache-2.0",

--- a/packages/template-tab-navigation-vue/tsconfig.json
+++ b/packages/template-tab-navigation-vue/tsconfig.json
@@ -8,12 +8,11 @@
     "sourceMap": true,
     "noEmitHelpers": true,
     "importHelpers": true,
-    "baseUrl": ".",
     "paths": {
-      "~/*": ["app/*"],
-      "@/*": ["app/*"]
+      "~/*": ["./app/*"],
+      "@/*": ["./app/*"]
     },
-    "typeRoots": ["types"],
+    "typeRoots": ["./types", "./node_modules/@types"],
     "types": ["node"],
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,

--- a/packages/template-tab-navigation/package.json
+++ b/packages/template-tab-navigation/package.json
@@ -39,7 +39,7 @@
     "url": "https://github.com/NativeScript/NativeScript/issues"
   },
   "dependencies": {
-    "@nativescript/core": "~9.0.0",
+    "@nativescript/core": "~9.1.0",
     "@nativescript/theme": "^3.1.0"
   },
   "devDependencies": {

--- a/packages/template-tab-navigation/package.json
+++ b/packages/template-tab-navigation/package.json
@@ -3,7 +3,7 @@
   "main": "app/app.js",
   "displayName": "Tabs",
   "templateType": "App template",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "Tabbed interface template",
   "author": "NativeScript Team <oss@nativescript.org>",
   "license": "Apache-2.0",


### PR DESCRIPTION
Bumps `typescript` to `~6.0.0` (resolves 6.0.3) across all 23 templates.

- 6 Angular templates additionally bumped to `@angular/*` `~22.0.0`, `@nativescript/angular` `^22.0.0`, and `zone.js` `~0.16.0` — Angular 18/20 peer-reject TypeScript 6.
- `tsconfig.json` updated across all 23 templates: removed deprecated `baseUrl`, relativized path mappings, added `skipLibCheck` where needed, widened `typeRoots`.
- Verified typechecking cleanly under TS6: blank-ts, blank-react, blank-solid-ts, master-detail-ts, tab-navigation-ts, blank-vue-vision, hello-world-ng, master-detail-ng, blank-svelte, tab-navigation-vue.
- Not independently re-verified (same edits applied, disk-time tradeoff during upgrade): blank-ng, tab-navigation-ng, drawer-navigation-ng, hello-world-ng-vision, and the remaining vue/svelte vision variants.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a3c1b6586478762f1accdeb/sessions/typescript-6-d59411d5)
<!-- polygraph-session-end -->